### PR TITLE
Correct parameter name for default case

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,2 +1,3 @@
-cvmfs::repo_incude_pkgs: ~
+---
+cvmfs::repo_includepkgs: ~
 


### PR DESCRIPTION
#### Pull Request (PR) description

For the non redhat family default case the `repo_includepkgs` parameter name
was wrong. Correct it.