### PR TITLE
Release 8.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,299 +1,434 @@
-## 2020-08-13 - Release 7.3.0
-- New `cvmfs_repositories` parameter to exactly specify `CVMFS_REPOSITORIES` in
-  `default.local` as used by `cvmfs_config probe` for instance.
-
-## 2020-08-11 - Release 7.2.0
-- New `cvmfs_repository_tag` parameter to mount command.
-
-## 2020-06-34 - Release 7.1.0
-- New pararmeter `cvmfs_instrument_fuse` parameter.
-- Enable cmvfs-fsck.timer so it starts on boot.
-- Remove legacy limits module requirement.
-
-## 2020-02-10 - Release 7.0.1
-- Bugfix on CentOS 8 only. Files in `/etc/autofs.master.d/`
-  must end in .autofs to be included.
-## 2020-01-06 - Release 7.0.0
-- remove SLC5 support
-- Add CentOS 8 support
-- fsck cron jobs are now a systemd timer on 8
-- A file is placed in auto.master.d rather than editing auto.master
-- New parameters `cvmfs_shared_cache` and `cvmfs_alien_cache`
-- Docs - correct cvmfs mount hash example
-- `cvmfs_yum_includepkgs` now accepts an array of packages. Setting it as a string
-  of packages is deprecated.
-
-## 2019-03-14 - Release 6.2.0
-- Support cvmfs_http_proxy on a mount
-
-## 2019-01-28 - Release 6.1.0
-- Support EXTERNAL repository parameters
-
-## 2018-12-03 - Release 6.0.1
-- Rely on $PATH to find `nice` command in fsck cron.
-
-## 2018-12-03 - Release 6.0.0
-- New parameters `cvmfs_dns_min_ttl` and `cvmfs_dns_max_ttl`.
-  Unit is in seconds, support added in `cvmfs-2.5.2`
-- New parameter `cvmfs_yum_priority` to set yum repo priority.
-  The default is the existing value so no change.
-- Fixtures for Puppet6 support.
-- All the deprecated explicit hiera calls that were issuing
-  notify calls for the last year have been completely removed.
-- Puppet 4 types have now been added and much stronger
-  type checking of input is now done. e.g while a
-  `cvmfs_quota_limit` of `'1234'` or `1234` used to be permitted only
-  the latter is now permitted.
-
-## 2018-06-28 - Release 5.2.0
-- New stratum one configuration `mime_expire` defaulting 61 seconds.
-
-## 2018-06-28 - Release 5.1.0
-- `cvmfs_force_singing` parameter removed. Not used by cvmfs for years.
-- The selinux context for the cache is now correctly set to `cvmfs_cache_t`
-- The tmpclean of quarantine directory only runs if quarantine directory exists.
-- Fix paths to awk, nice.
-- Support debian based distributions for the first time.
-
-
-## 2018-01-24 - Release 5.0.0
-- Deprecates the following explicit hiera variables:
-
-  `cvmfs_quota_limit`, `cvmfs_quota_ratio`, `cvmfs_http_proxy`, `cvmfs_server_url`, `cvmfs_cache_base`,
-  `cvmfs_timeout`, `cvmfs_timeout_direct`, `cvmfs_nfiles`, `cvmfs_public_key`, `cvmfs_force_signing`,
-  `cvmfs_syslog_level`, `cvmfs_tracefile`, `cvmfs_debuglog`, `cvmfs_max_ttl`, `cvmfs::mount`,
-  `cvmfs_yum`, `cvmfs_yum_testing`, `cvmfs_yum_testing_enabled`, `cvmfs_kernel_version`, `cvmfs_yum_kernel`,
-  `cvmfs_yum_kernel_enabled`, `cvmfs_sync_minute`.
-
-  In almost every case the existing conventional class parameter can be used instead.
-  e.g `cvmfs_quota_limit` becomes `cvmfs::cvmfs_quota_limit`. The class parameter
-  can be specified via hiera if so wished.
-  These parameters have been available, documented and advised for sometime.
-
-  Any use of the above explicit hiera lookups will work for now but a `notify` will be issued offering
-  advice on what action to take.
-
-  The next version `puppet-cvmfs` will completely drop thier support as well as support for puppet3.
-
-## 2017-05-18 - Release 4.2.0
-- New paramter `mime_expire` to `cvmfs::zero` to specify
-  expirey headers for cvmfs files in apache. Defaults
-  to `120`. Unit is seconds.
-- New optional parameter `cvmfs_claim_ownership` to main class
-  and to mount type.
-- Bugfixes for latest concat modules.
-
-
-## 2017-04-04 - Release 4.1.0
-- New parameter `cvmfs_memcache_size` to main class and
-  to mount type.
-
-## 2017-02-15 - Release 4.0.0
-- cvmfs::server is now deprecated and will be removed
-  at next release. README.md contains details
-  for migating to cvmfs::zero defined type.
-
-## 2017-02-08 - Release 3.2.0
-- Updates for cvmfs_server version 2.3
-
-## 2016-09-14 - Release 3.1.0
-- Wrap autofs service with ensure_resource to make co-existing
-  easier.
-
-## 2016-08-18 - Release 3.0.1
-- Bug fix fact for ruby 1.8
-
-## 2016-08-18 - Release 3.0.0
-
-- DEPRCATION: Variable `cvmfs::config_automounter` is now deprecated.
-  If it is set to the non default `false` compilation will fail.
-- New variable `cvmfs::mount_method` is a string defaulting
-  to `autofs` and provides the current default behaviour to use
-  automounter configuration. It can also be set to `mount`
-  in which will use the puppet mount type which currently
-  mounts and adds an `/etc/fstab` entry.
-  It can also be set to `none` in which case no mount
-  configuration will be applied.
-- Fixes #56 tmpwatch is now installed if fsck crons are
-  enabled.
-
-## 2016-04-29 - Release 2.0.0
-
-- Remove all support for cvmfs 2.0.
-- Only one rather than two puppet runs are now
-  requied.
-- Drop bundled augeas automaster lens.
-- Stratum 1 apache file update for cvmfs 2.2.
-
-
-## 2016-03-07 - Release 1.0.3
-
-- Stratum 1 cron jobs more frequent.
-
-## 2016-03-07 - Release 1.0.2
-
-- Puppetforge publish problem
-
-## 2016-03-04 - Release 1.0.0
-
-- New parameter `cvmfs::cvmfs_yum_manage_repo` defaults to true
-  allows all yum managment to be disabled. Baptiste Grenier
-- Package installations now wrapped in ensure_package to
-  ease duplicate declarations
-  Pat Riehecky
-- Stratum 0 only, new parameter `cvmfs::zero::creator_version` defaults
-  to `2.1.19`.
-- Stratum 0 only, new json mime types to support cvmfs 2.2.
-- Stratum 0 only, rdonly directory no longer mounted at boot time.
-- Stratum 0 only, backwards incompatible change, the gid and group
-  name now *MUST* be specified.
-- Fixes for puppet 4 support.
-
-
-## 2015-08-04 - Release 0.9.0
-
-- A tmpwatch -f 30d now runs as weekly cron withing
-  cvmfs::fsck to purge quarentined files.
-
-## 2015-07-07 - Release 0.8.0
-
-## Features
-- Tests now check default configuration do not change.
-- CVMFS_FOLLOW_REDIRECTS can now be set globally, per repo or per domain.
-- New onreboot paramter to fsck module runs an fsck on reboot. Default false.
-- zfs kernel module built for aufs kernel may now be installed on stratum0s.
-
-## 2015-06-22 - Release 0.7.0
-## Features
-- New option defaults cvmfs::fsck::options allows
-  an option, e.g. -p to parsed to cvmfs_fsck cron.
-
-## Bugfixes
-- Reintroduce $::concat_basedir in tests since
-  puppetlabs-concat was reverted to version 1.
-
-## 2015-06-10 - Release 0.6.0
-## Features
-- Garbage collection parameters for stratum 0.
-- CVMFS_IGNORE_XDIR_HARDLINKS can be set on stratum 0.
-
-##2015-05-06 - Release 0.5.0
-## Deprecations
-- All the hiera variables explicity called from params.pp
-  file are now deprecated. These variables include.
-  `cvmfs_config_automaster`, `cvmfs_quota_limit`,
-  `cvmfs_quota_limit`, `cvmfs_quota_ratio`, `cvmfs_http_proxy`,
-  `cvmfs_server_url`, `cvmfs_cache_base`, `cvmfs_timeout`,
-  `cvmfs_nfiles`, `cvmfs_public_key`, `cvmfs_force_signing`,
-  `cvmfs_syslog_level`, `cvmfs_tracefile`, `cvmfs_debuglog`
-  `cvmfs_max_ttl`, `cvmfs::mount`, `cvmfsversion`,
-  `cvmfs_yum`, `cvmfs_yum_testing`, `cvmfs_yum_proxy`
-  `cvmfs_kernel_version`, `cvmfs_yum_kernel`, `cvmfs_yum_kernel_enabled`
-  Instead use the hiera binding that maps to one of the paramters
-  of the `cvmfs` class, e.g `cvmfs_quota_limit` becomes `cvmfs::cvmfs_quota_limit`
-  A future version of this module will print a warning if these
-  variables are still being used.
-
-
-## Features
-- Beaker acceptence tests now added for client. Configures
-  a client and mounts the cms.cern.ch and atlas.cern.ch
-  repositories.
-- The fact ::operatingsystemmajrelease is used everywhere now
-  to determine major OS version.
-- Unit tests for yumrepos.
-- The GPG key location for packages in the cvmfs yum repositories
-  can now be specified.
-- The GPG check of packages can be disabled in the yum repository
-  configuration.
-- The new cvmfs-config repository is now configured but is disabled
-  by default.
-
-
-## Bugfixes
-- The examples in the README now work.
-
-## 2015-04-30 - Release 0.4.4
-### Bugfixes
-- Correct erwbgy-limits version dependency.
-
-##2015-04-30 - Release 0.4.3
-### Bugfixes
-- Fix github to puppetforge publishing.
-
-## 2015-04-30 - Release 0.4.2
-### Bugfixes
-- Fix github to puppetforge publishing.
-
-## 2015-04-29 - Release 0.4.1
-### Bugfixes
-- Fix github to puppetforge publishing.
-
-## 2015-04-29 - Release 0.4.0
-
-### Features
-- New paramter `cvmfs_repo_list` allows entries of CVMFS_REPOSITORIES to be fine
-  tuned per cvmfs::mount. https://github.com/cvmfs/puppet-cvmfs/pull/22
-- New paramter `manage_autofs_service` controls if autofs service should
-  be managed module. Existing paramter `config_automaster` now only configures
-  `auto.master file` - @jcpunk.
-- New type cvmfs::zero to configure a CvmFS stratum 0. The existing
-  class cvmfs::server for stratum 0s will be deprecated at some
-  future date.
-- Doc changes for latest PL style guide. CHANGELOG is now markdown.
-  Docs for classes and types being migrated from them to README.md.
-- puppet-cvmfs is now autodeployed to puppetforge once tagged.
-- CvmFS env settings can now be set globally as well per domain or mount.
-- New variable `cvmfs_domain_hash` allows a hash of CvmFS domains to
-  loaded from hiera.
-- New variable `cvmfs_use_geoapi` can be set globally, per domain or
-  mount to influence `CVMFS_USE_GEOAPI`
-- rspec functional tests now exist for class cvmfs and types
-  cvmfs::zero, cvmfs::mount and cvmfs::domain.
-
-
-### Bugfixes
-- cvmfs-config* packages can now be installed on cvmfs servers.
-- All references to deprecated concat::setup removed - @berghaus.
-- Vague use of undef was failing under furture parser or puppet
-  4.0
-
-## 2015-03-06 - Release 0.3.3
-
-### Features
-- do not control autofs service when asked not to.
-- Install mod_wsgi and configure for geoip on stratum 1.
-- Allow a http proxy for yum repos to be configured.
-- Migrate to puppetlabs lint tests.
-
-### Bugfixes
-
-## 2014-06-18 - Release 0.3.2
-
-### Features
-- server - seperate yum configuration for server and client.
-- server - Add `nofiles` paramter to server class to allow no open files to
-  be specified for the user running the cvmfs server.
-- server - An exact kernel version is no longer specified.
-- README file converted to markdown, now README.md.
-- client - new defined type cvmfs::domain to create <domain>.local file in
-  /etc/cvmfs/domain.d.
-- client - cvmfs::init class is now paramatised so supports that in addition to hiera.
-
-### Bugfixes
-- server - force a public key file location to be specified.
-- server - when disabling selinux on server specify an augeas scope
-
-## 2014-03-27 - Release 0.2.2
-
-### Features
-
-### Bugfixes
-- bugfix for cvmfs_public_key variable.
-
-## 2014-01-16 - Release 0.2.1
-
-### Features
-
-### Bugfixes
--  Puppet 3.4 compatability for ensure_resources.
+# Changelog
+
+All notable changes to this project will be documented in this file.
+Each new release typically also includes the latest modulesync defaults.
+These should not affect the functionality of the module.
+
+## [v8.0.0](https://github.com/voxpupuli/puppet-cvmfs/tree/v8.0.0) (2021-03-23)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/v7.3.0...v8.0.0)
+
+**Breaking changes:**
+
+- Remove 'yum' string from class parameters [\#123](https://github.com/voxpupuli/puppet-cvmfs/pull/123) ([traylenator](https://github.com/traylenator))
+- Add type enforcement to cvmfs::mount and cvmfs::domain [\#122](https://github.com/voxpupuli/puppet-cvmfs/pull/122) ([traylenator](https://github.com/traylenator))
+- Drop all CvmFS server code [\#113](https://github.com/voxpupuli/puppet-cvmfs/pull/113) ([traylenator](https://github.com/traylenator))
+
+**Implemented enhancements:**
+
+- Add CVMFS\_IPFAMILY\_PREFER config parameter [\#125](https://github.com/voxpupuli/puppet-cvmfs/pull/125) ([luisfdez](https://github.com/luisfdez))
+- Add ubuntu 18.04, 20.04 and debian 10 support [\#124](https://github.com/voxpupuli/puppet-cvmfs/pull/124) ([traylenator](https://github.com/traylenator))
+- Convert main config template to epp [\#118](https://github.com/voxpupuli/puppet-cvmfs/pull/118) ([traylenator](https://github.com/traylenator))
+
+**Fixed bugs:**
+
+- cvmfs\_external\_url parameter to mount fixed [\#127](https://github.com/voxpupuli/puppet-cvmfs/pull/127) ([traylenator](https://github.com/traylenator))
+- Correct parameter name for default case [\#126](https://github.com/voxpupuli/puppet-cvmfs/pull/126) ([traylenator](https://github.com/traylenator))
+
+**Merged pull requests:**
+
+- Update all documentation [\#128](https://github.com/voxpupuli/puppet-cvmfs/pull/128) ([traylenator](https://github.com/traylenator))
+- Use modern splat rather than create resources [\#121](https://github.com/voxpupuli/puppet-cvmfs/pull/121) ([traylenator](https://github.com/traylenator))
+- Whitespace, Automatic lint and Rubocop Fixes [\#114](https://github.com/voxpupuli/puppet-cvmfs/pull/114) ([traylenator](https://github.com/traylenator))
+- Increase upper version of firewall module [\#112](https://github.com/voxpupuli/puppet-cvmfs/pull/112) ([sorrison](https://github.com/sorrison))
+- cvmfs::install: Fact file creation must depend on Package\[cvmfs\]. [\#111](https://github.com/voxpupuli/puppet-cvmfs/pull/111) ([olifre](https://github.com/olifre))
+- Add UID\_MAP and GID\_MAP functionality. [\#110](https://github.com/voxpupuli/puppet-cvmfs/pull/110) ([olifre](https://github.com/olifre))
+- add missing package require for file ownership [\#104](https://github.com/voxpupuli/puppet-cvmfs/pull/104) ([fschaer](https://github.com/fschaer))
+
+## [v7.3.0](https://github.com/voxpupuli/puppet-cvmfs/tree/v7.3.0) (2020-08-13)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/v7.2.0...v7.3.0)
+
+**Merged pull requests:**
+
+- New cvmfs\_repositories parameter [\#106](https://github.com/voxpupuli/puppet-cvmfs/pull/106) ([traylenator](https://github.com/traylenator))
+
+## [v7.2.0](https://github.com/voxpupuli/puppet-cvmfs/tree/v7.2.0) (2020-08-11)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/v7.1.1...v7.2.0)
+
+**Merged pull requests:**
+
+- Support per mount CVMFS\_REPOSITORY\_TAG specification [\#105](https://github.com/voxpupuli/puppet-cvmfs/pull/105) ([traylenator](https://github.com/traylenator))
+
+## [v7.1.1](https://github.com/voxpupuli/puppet-cvmfs/tree/v7.1.1) (2020-06-24)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/v7.1.0...v7.1.1)
+
+## [v7.1.0](https://github.com/voxpupuli/puppet-cvmfs/tree/v7.1.0) (2020-06-24)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/v7.0.1...v7.1.0)
+
+**Closed issues:**
+
+- cvmfs-fsck.timer ist not enabled [\#99](https://github.com/voxpupuli/puppet-cvmfs/issues/99)
+- Replace erwbgy/limits with actively maintained module [\#95](https://github.com/voxpupuli/puppet-cvmfs/issues/95)
+
+**Merged pull requests:**
+
+- New cvmfs\_instrument\_fuse parameter [\#102](https://github.com/voxpupuli/puppet-cvmfs/pull/102) ([traylenator](https://github.com/traylenator))
+- Remove limits module and usage [\#101](https://github.com/voxpupuli/puppet-cvmfs/pull/101) ([traylenator](https://github.com/traylenator))
+- cvmfs::fsck: Enable cvmfs-fsck.timer. [\#100](https://github.com/voxpupuli/puppet-cvmfs/pull/100) ([olifre](https://github.com/olifre))
+
+## [v7.0.1](https://github.com/voxpupuli/puppet-cvmfs/tree/v7.0.1) (2020-02-10)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/v7.0.0...v7.0.1)
+
+**Merged pull requests:**
+
+- Drop files in autofs.master.d must end in .autofs [\#96](https://github.com/voxpupuli/puppet-cvmfs/pull/96) ([traylenator](https://github.com/traylenator))
+
+## [v7.0.0](https://github.com/voxpupuli/puppet-cvmfs/tree/v7.0.0) (2020-01-06)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/v6.2.0...v7.0.0)
+
+**Merged pull requests:**
+
+- Remove SLC5 add C8 support [\#94](https://github.com/voxpupuli/puppet-cvmfs/pull/94) ([traylenator](https://github.com/traylenator))
+- Correct cvmfs::cvmfs\_hash usage in example [\#93](https://github.com/voxpupuli/puppet-cvmfs/pull/93) ([traylenator](https://github.com/traylenator))
+- add two optional parameters [\#92](https://github.com/voxpupuli/puppet-cvmfs/pull/92) ([Takadonet](https://github.com/Takadonet))
+- cvmfs::fsck: Add ionice and a short sleep before fsck start. [\#91](https://github.com/voxpupuli/puppet-cvmfs/pull/91) ([olifre](https://github.com/olifre))
+- yum: Allow to override includepkgs, default unchanged. [\#90](https://github.com/voxpupuli/puppet-cvmfs/pull/90) ([olifre](https://github.com/olifre))
+
+## [v6.2.0](https://github.com/voxpupuli/puppet-cvmfs/tree/v6.2.0) (2019-03-14)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/v6.1.0...v6.2.0)
+
+**Merged pull requests:**
+
+- Forward CVMFS\_HTTP\_PROXY param to erb template [\#89](https://github.com/voxpupuli/puppet-cvmfs/pull/89) ([ebocchi](https://github.com/ebocchi))
+
+## [v6.1.0](https://github.com/voxpupuli/puppet-cvmfs/tree/v6.1.0) (2019-01-28)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/v6.0.1...v6.1.0)
+
+**Merged pull requests:**
+
+- New cvmfs\_external\_ parameters [\#88](https://github.com/voxpupuli/puppet-cvmfs/pull/88) ([traylenator](https://github.com/traylenator))
+
+## [v6.0.1](https://github.com/voxpupuli/puppet-cvmfs/tree/v6.0.1) (2018-12-03)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/6.0.0...v6.0.1)
+
+## [6.0.0](https://github.com/voxpupuli/puppet-cvmfs/tree/6.0.0) (2018-12-03)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/v6.0.0...6.0.0)
+
+## [v6.0.0](https://github.com/voxpupuli/puppet-cvmfs/tree/v6.0.0) (2018-12-03)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/5.2.0...v6.0.0)
+
+**Closed issues:**
+
+- cvmfs\_server\_url deprecation warning issues out of the box [\#83](https://github.com/voxpupuli/puppet-cvmfs/issues/83)
+
+**Merged pull requests:**
+
+- New dns\_min,max\_ttl variables [\#87](https://github.com/voxpupuli/puppet-cvmfs/pull/87) ([traylenator](https://github.com/traylenator))
+- New yum\_priority parameter [\#86](https://github.com/voxpupuli/puppet-cvmfs/pull/86) ([traylenator](https://github.com/traylenator))
+-  Modernise CERNOps-cvmfs module [\#85](https://github.com/voxpupuli/puppet-cvmfs/pull/85) ([traylenator](https://github.com/traylenator))
+
+## [5.2.0](https://github.com/voxpupuli/puppet-cvmfs/tree/5.2.0) (2018-06-28)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/5.1.0...5.2.0)
+
+**Closed issues:**
+
+- Catalog timeouts mismatched with CVMFS default [\#81](https://github.com/voxpupuli/puppet-cvmfs/issues/81)
+
+**Merged pull requests:**
+
+- Fixes \#81 New mime\_expire parameter to stratum 1s [\#82](https://github.com/voxpupuli/puppet-cvmfs/pull/82) ([traylenator](https://github.com/traylenator))
+- Add puppet 5 to tests [\#80](https://github.com/voxpupuli/puppet-cvmfs/pull/80) ([traylenator](https://github.com/traylenator))
+
+## [5.1.0](https://github.com/voxpupuli/puppet-cvmfs/tree/5.1.0) (2018-06-28)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/5.0.0...5.1.0)
+
+**Closed issues:**
+
+- Strange set of options for tmpwatch [\#71](https://github.com/voxpupuli/puppet-cvmfs/issues/71)
+- Default SELinux context is incorrect.  [\#68](https://github.com/voxpupuli/puppet-cvmfs/issues/68)
+- non-existent option CVMFS\_FORCE\_SIGNING  is set automatically [\#66](https://github.com/voxpupuli/puppet-cvmfs/issues/66)
+- CVMFS\_CLAIM\_OWNERSHIP for clients [\#62](https://github.com/voxpupuli/puppet-cvmfs/issues/62)
+- Improve error message when running at CERN an pluginsync is in operation. [\#49](https://github.com/voxpupuli/puppet-cvmfs/issues/49)
+
+**Merged pull requests:**
+
+- Prepare 5.1.0 [\#79](https://github.com/voxpupuli/puppet-cvmfs/pull/79) ([traylenator](https://github.com/traylenator))
+- Fixes \#66 drop CVMFS\_FORCE\_SIGNING [\#78](https://github.com/voxpupuli/puppet-cvmfs/pull/78) ([traylenator](https://github.com/traylenator))
+- Fixes \#68 Correct selinux context for cache [\#77](https://github.com/voxpupuli/puppet-cvmfs/pull/77) ([traylenator](https://github.com/traylenator))
+- Set catalog timeouts to 30s [\#76](https://github.com/voxpupuli/puppet-cvmfs/pull/76) ([traylenator](https://github.com/traylenator))
+- clean\_quarantaine to check for directory existence [\#75](https://github.com/voxpupuli/puppet-cvmfs/pull/75) ([traylenator](https://github.com/traylenator))
+- cmvfs::params: Remove hard abort on Debian. [\#74](https://github.com/voxpupuli/puppet-cvmfs/pull/74) ([olifre](https://github.com/olifre))
+- fsck: Fix path for awk. [\#73](https://github.com/voxpupuli/puppet-cvmfs/pull/73) ([olifre](https://github.com/olifre))
+- cvmfs::fsck: tmpwatch on RedHat, tmpreaper on Debian. [\#72](https://github.com/voxpupuli/puppet-cvmfs/pull/72) ([olifre](https://github.com/olifre))
+- Do not disable SELinux for Stratum 0 / Stratum 1. [\#70](https://github.com/voxpupuli/puppet-cvmfs/pull/70) ([olifre](https://github.com/olifre))
+- Prepare 5.0.0 [\#69](https://github.com/voxpupuli/puppet-cvmfs/pull/69) ([traylenator](https://github.com/traylenator))
+
+## [5.0.0](https://github.com/voxpupuli/puppet-cvmfs/tree/5.0.0) (2018-01-24)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/4.2.0...5.0.0)
+
+**Merged pull requests:**
+
+- Deprecate all explicit hiera calls in params.pp [\#34](https://github.com/voxpupuli/puppet-cvmfs/pull/34) ([traylenator](https://github.com/traylenator))
+
+## [4.2.0](https://github.com/voxpupuli/puppet-cvmfs/tree/4.2.0) (2017-05-18)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/4.1.0...4.2.0)
+
+**Merged pull requests:**
+
+- New expireation timeout paramter for stratum zero parameters  [\#65](https://github.com/voxpupuli/puppet-cvmfs/pull/65) ([traylenator](https://github.com/traylenator))
+- Use a puppet3 supporting concat version [\#64](https://github.com/voxpupuli/puppet-cvmfs/pull/64) ([traylenator](https://github.com/traylenator))
+- added cvmfs\_claim\_ownership for the client configuration [\#63](https://github.com/voxpupuli/puppet-cvmfs/pull/63) ([mboisson](https://github.com/mboisson))
+
+## [4.1.0](https://github.com/voxpupuli/puppet-cvmfs/tree/4.1.0) (2017-04-04)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/puppet-cvmfs-4.0.0...4.1.0)
+
+**Merged pull requests:**
+
+- New parameter cvmfs\_memcache\_size [\#61](https://github.com/voxpupuli/puppet-cvmfs/pull/61) ([traylenator](https://github.com/traylenator))
+
+## [puppet-cvmfs-4.0.0](https://github.com/voxpupuli/puppet-cvmfs/tree/puppet-cvmfs-4.0.0) (2017-02-15)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/puppet-cvmfs-3.2.0...puppet-cvmfs-4.0.0)
+
+## [puppet-cvmfs-3.2.0](https://github.com/voxpupuli/puppet-cvmfs/tree/puppet-cvmfs-3.2.0) (2017-02-08)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/puppet-cvmfs-3.1.0...puppet-cvmfs-3.2.0)
+
+**Merged pull requests:**
+
+- Dan's commits CERN [\#60](https://github.com/voxpupuli/puppet-cvmfs/pull/60) ([traylenator](https://github.com/traylenator))
+- Purge config.d directory [\#59](https://github.com/voxpupuli/puppet-cvmfs/pull/59) ([rwf14f](https://github.com/rwf14f))
+- Bug, do not require yumrepo if not included [\#58](https://github.com/voxpupuli/puppet-cvmfs/pull/58) ([traylenator](https://github.com/traylenator))
+
+## [puppet-cvmfs-3.1.0](https://github.com/voxpupuli/puppet-cvmfs/tree/puppet-cvmfs-3.1.0) (2016-09-14)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/puppet-cvmfs-3.0.1...puppet-cvmfs-3.1.0)
+
+## [puppet-cvmfs-3.0.1](https://github.com/voxpupuli/puppet-cvmfs/tree/puppet-cvmfs-3.0.1) (2016-08-18)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/puppet-cvmfs-3.0.0...puppet-cvmfs-3.0.1)
+
+## [puppet-cvmfs-3.0.0](https://github.com/voxpupuli/puppet-cvmfs/tree/puppet-cvmfs-3.0.0) (2016-08-18)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/puppet-cvmfs-2.0.0...puppet-cvmfs-3.0.0)
+
+**Closed issues:**
+
+- Missing packages/hidden dependency? [\#56](https://github.com/voxpupuli/puppet-cvmfs/issues/56)
+- cvmfs::one::install does not inherit any params. [\#53](https://github.com/voxpupuli/puppet-cvmfs/issues/53)
+- Drop autofs lens [\#51](https://github.com/voxpupuli/puppet-cvmfs/issues/51)
+- Drop cvmfs 2.0 support [\#50](https://github.com/voxpupuli/puppet-cvmfs/issues/50)
+- Support fstab entry for cvmfs mounts. [\#41](https://github.com/voxpupuli/puppet-cvmfs/issues/41)
+
+## [puppet-cvmfs-2.0.0](https://github.com/voxpupuli/puppet-cvmfs/tree/puppet-cvmfs-2.0.0) (2016-04-29)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/puppet-cvmfs-1.0.3...puppet-cvmfs-2.0.0)
+
+**Merged pull requests:**
+
+- Drop cmvfs 2.0.x support  [\#52](https://github.com/voxpupuli/puppet-cvmfs/pull/52) ([arbreezy](https://github.com/arbreezy))
+
+## [puppet-cvmfs-1.0.3](https://github.com/voxpupuli/puppet-cvmfs/tree/puppet-cvmfs-1.0.3) (2016-03-14)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/puppet-cmvfs-1.0.2...puppet-cvmfs-1.0.3)
+
+**Merged pull requests:**
+
+- one: sync in parallel at 15 minute intervals [\#48](https://github.com/voxpupuli/puppet-cvmfs/pull/48) ([dvanders](https://github.com/dvanders))
+
+## [puppet-cmvfs-1.0.2](https://github.com/voxpupuli/puppet-cvmfs/tree/puppet-cmvfs-1.0.2) (2016-03-07)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/puppet-cvmfs-1.0.1...puppet-cmvfs-1.0.2)
+
+## [puppet-cvmfs-1.0.1](https://github.com/voxpupuli/puppet-cvmfs/tree/puppet-cvmfs-1.0.1) (2016-03-04)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/puppet-cmvfs-1.0.0...puppet-cvmfs-1.0.1)
+
+## [puppet-cmvfs-1.0.0](https://github.com/voxpupuli/puppet-cvmfs/tree/puppet-cmvfs-1.0.0) (2016-03-04)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/puppet-cvmfs-0.9.0...puppet-cmvfs-1.0.0)
+
+**Closed issues:**
+
+- Configuration never taking place [\#44](https://github.com/voxpupuli/puppet-cvmfs/issues/44)
+
+**Merged pull requests:**
+
+- The operatingsytem fact must be set. [\#47](https://github.com/voxpupuli/puppet-cvmfs/pull/47) ([traylenator](https://github.com/traylenator))
+- New stratum 0 options for cvmfs 2.2. [\#46](https://github.com/voxpupuli/puppet-cvmfs/pull/46) ([traylenator](https://github.com/traylenator))
+- use ensure\_packages to avoid "redef errors" [\#45](https://github.com/voxpupuli/puppet-cvmfs/pull/45) ([jcpunk](https://github.com/jcpunk))
+- cvmf::install: allow to disable yum repository management [\#43](https://github.com/voxpupuli/puppet-cvmfs/pull/43) ([gwarf](https://github.com/gwarf))
+- Run acceptence tests on travis docker [\#42](https://github.com/voxpupuli/puppet-cvmfs/pull/42) ([traylenator](https://github.com/traylenator))
+
+## [puppet-cvmfs-0.9.0](https://github.com/voxpupuli/puppet-cvmfs/tree/puppet-cvmfs-0.9.0) (2015-08-04)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/puppet-cvmfs-0.8.1...puppet-cvmfs-0.9.0)
+
+**Closed issues:**
+
+- typo in $cvmfs\_yum\_testing\_enabled parameter in init.pp [\#40](https://github.com/voxpupuli/puppet-cvmfs/issues/40)
+- coveralls.io support? [\#25](https://github.com/voxpupuli/puppet-cvmfs/issues/25)
+
+**Merged pull requests:**
+
+- Additional option CVMFS\_MOUNT\_RW in repo.local template. [\#36](https://github.com/voxpupuli/puppet-cvmfs/pull/36) ([mrolli](https://github.com/mrolli))
+
+## [puppet-cvmfs-0.8.1](https://github.com/voxpupuli/puppet-cvmfs/tree/puppet-cvmfs-0.8.1) (2015-07-07)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/puppet-cvmfs-0.8.0...puppet-cvmfs-0.8.1)
+
+## [puppet-cvmfs-0.8.0](https://github.com/voxpupuli/puppet-cvmfs/tree/puppet-cvmfs-0.8.0) (2015-07-07)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/puppet-cvmfs-0.7.0...puppet-cvmfs-0.8.0)
+
+**Closed issues:**
+
+- CVMFS\_FOLLOW\_REDIRECTS=yes [\#39](https://github.com/voxpupuli/puppet-cvmfs/issues/39)
+
+## [puppet-cvmfs-0.7.0](https://github.com/voxpupuli/puppet-cvmfs/tree/puppet-cvmfs-0.7.0) (2015-06-22)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/puppet-cvmfs-0.6.0...puppet-cvmfs-0.7.0)
+
+## [puppet-cvmfs-0.6.0](https://github.com/voxpupuli/puppet-cvmfs/tree/puppet-cvmfs-0.6.0) (2015-06-10)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/puppet-cvmfs-0.5.0...puppet-cvmfs-0.6.0)
+
+**Closed issues:**
+
+- CVMFS\_IGNORE\_XDIR\_HARDLINKS=true [\#38](https://github.com/voxpupuli/puppet-cvmfs/issues/38)
+
+**Merged pull requests:**
+
+- Fixed package names in dependency list. [\#37](https://github.com/voxpupuli/puppet-cvmfs/pull/37) ([mrolli](https://github.com/mrolli))
+- README.md has drifted abit from the current feature set of init.pp [\#35](https://github.com/voxpupuli/puppet-cvmfs/pull/35) ([jcpunk](https://github.com/jcpunk))
+
+## [puppet-cvmfs-0.5.0](https://github.com/voxpupuli/puppet-cvmfs/tree/puppet-cvmfs-0.5.0) (2015-05-06)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/puppet-cvmfs-0.4.4...puppet-cvmfs-0.5.0)
+
+**Closed issues:**
+
+- Client configuration in README.md provides invalid example [\#28](https://github.com/voxpupuli/puppet-cvmfs/issues/28)
+
+**Merged pull requests:**
+
+- Fixes \#28 - Readme examples should now all work. [\#33](https://github.com/voxpupuli/puppet-cvmfs/pull/33) ([traylenator](https://github.com/traylenator))
+- Simple ls /cvmfs/atlas.cern.ch/repo as first acceptence test' [\#32](https://github.com/voxpupuli/puppet-cvmfs/pull/32) ([traylenator](https://github.com/traylenator))
+- Notice seems a bit low for these messages [\#31](https://github.com/voxpupuli/puppet-cvmfs/pull/31) ([jcpunk](https://github.com/jcpunk))
+- I've configured this module to point to OSG cvmfs package, but can't install them [\#30](https://github.com/voxpupuli/puppet-cvmfs/pull/30) ([jcpunk](https://github.com/jcpunk))
+- List other OS platforms this works on [\#27](https://github.com/voxpupuli/puppet-cvmfs/pull/27) ([jcpunk](https://github.com/jcpunk))
+
+## [puppet-cvmfs-0.4.4](https://github.com/voxpupuli/puppet-cvmfs/tree/puppet-cvmfs-0.4.4) (2015-04-30)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/puppet-cvmfs-0.4.3...puppet-cvmfs-0.4.4)
+
+**Closed issues:**
+
+- v0.4.3 unable to resolve dependency 'erwbgy-limits' \(\>=1.0.0\) [\#26](https://github.com/voxpupuli/puppet-cvmfs/issues/26)
+
+## [puppet-cvmfs-0.4.3](https://github.com/voxpupuli/puppet-cvmfs/tree/puppet-cvmfs-0.4.3) (2015-04-30)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/puppet-cvmfs-0.4.2...puppet-cvmfs-0.4.3)
+
+## [puppet-cvmfs-0.4.2](https://github.com/voxpupuli/puppet-cvmfs/tree/puppet-cvmfs-0.4.2) (2015-04-30)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/puppet-cvmfs-0.4.1...puppet-cvmfs-0.4.2)
+
+## [puppet-cvmfs-0.4.1](https://github.com/voxpupuli/puppet-cvmfs/tree/puppet-cvmfs-0.4.1) (2015-04-29)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/puppet-cvmfs-0.4.0...puppet-cvmfs-0.4.1)
+
+**Closed issues:**
+
+- hiera\('key',undef\) Incompatible with future parser. [\#19](https://github.com/voxpupuli/puppet-cvmfs/issues/19)
+
+## [puppet-cvmfs-0.4.0](https://github.com/voxpupuli/puppet-cvmfs/tree/puppet-cvmfs-0.4.0) (2015-04-29)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/puppet-cvmfs-0.3.3...puppet-cvmfs-0.4.0)
+
+**Closed issues:**
+
+- cvmfs\_env\_variables for default.local [\#23](https://github.com/voxpupuli/puppet-cvmfs/issues/23)
+- autofs management is all or nothing [\#20](https://github.com/voxpupuli/puppet-cvmfs/issues/20)
+- cvmfs::mount type should support cvmfs\_http\_proxy option. [\#15](https://github.com/voxpupuli/puppet-cvmfs/issues/15)
+
+**Merged pull requests:**
+
+- Allow service to be managed seperately [\#21](https://github.com/voxpupuli/puppet-cvmfs/pull/21) ([jcpunk](https://github.com/jcpunk))
+- Remove concat setup dependency [\#18](https://github.com/voxpupuli/puppet-cvmfs/pull/18) ([berghaus](https://github.com/berghaus))
+- Allow cvmfs-config package to be installed [\#17](https://github.com/voxpupuli/puppet-cvmfs/pull/17) ([traylenator](https://github.com/traylenator))
+
+## [puppet-cvmfs-0.3.3](https://github.com/voxpupuli/puppet-cvmfs/tree/puppet-cvmfs-0.3.3) (2015-03-06)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/puppet-cvmfs-0.3.2...puppet-cvmfs-0.3.3)
+
+**Merged pull requests:**
+
+- yum proxy and checking autofs  [\#16](https://github.com/voxpupuli/puppet-cvmfs/pull/16) ([fmelaccio](https://github.com/fmelaccio))
+
+## [puppet-cvmfs-0.3.2](https://github.com/voxpupuli/puppet-cvmfs/tree/puppet-cvmfs-0.3.2) (2014-06-18)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/puppet-cmvfs-0.3.1...puppet-cvmfs-0.3.2)
+
+## [puppet-cmvfs-0.3.1](https://github.com/voxpupuli/puppet-cvmfs/tree/puppet-cmvfs-0.3.1) (2014-06-18)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/puppet-cvmfs-0.2.2...puppet-cmvfs-0.3.1)
+
+**Closed issues:**
+
+- module with 'domain' settings? [\#14](https://github.com/voxpupuli/puppet-cvmfs/issues/14)
+
+## [puppet-cvmfs-0.2.2](https://github.com/voxpupuli/puppet-cvmfs/tree/puppet-cvmfs-0.2.2) (2014-03-27)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/puppet-cvmfs-0.2.1...puppet-cvmfs-0.2.2)
+
+**Merged pull requests:**
+
+- fixed cvmfs\_public\_key name in template [\#13](https://github.com/voxpupuli/puppet-cvmfs/pull/13) ([rwf14f](https://github.com/rwf14f))
+
+## [puppet-cvmfs-0.2.1](https://github.com/voxpupuli/puppet-cvmfs/tree/puppet-cvmfs-0.2.1) (2014-01-16)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/puppet-cvmfs-0.2.0...puppet-cvmfs-0.2.1)
+
+## [puppet-cvmfs-0.2.0](https://github.com/voxpupuli/puppet-cvmfs/tree/puppet-cvmfs-0.2.0) (2013-12-09)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/puppet-cvmfs-0.1.0...puppet-cvmfs-0.2.0)
+
+## [puppet-cvmfs-0.1.0](https://github.com/voxpupuli/puppet-cvmfs/tree/puppet-cvmfs-0.1.0) (2013-12-04)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/puppet-cvmfs-0.0.2...puppet-cvmfs-0.1.0)
+
+**Closed issues:**
+
+- How to include CMS\_LOCAL\_SITE [\#8](https://github.com/voxpupuli/puppet-cvmfs/issues/8)
+- few typos [\#6](https://github.com/voxpupuli/puppet-cvmfs/issues/6)
+
+**Merged pull requests:**
+
+- Add stratum 0 and stratum 1 support. [\#12](https://github.com/voxpupuli/puppet-cvmfs/pull/12) ([traylenator](https://github.com/traylenator))
+- Add cvmfs\_server 2.1 support [\#11](https://github.com/voxpupuli/puppet-cvmfs/pull/11) ([traylenator](https://github.com/traylenator))
+- Confine cvmfspartsize fact to Linux kernel [\#10](https://github.com/voxpupuli/puppet-cvmfs/pull/10) ([luisfdez](https://github.com/luisfdez))
+- Adding environmental variables to CVMFS config [\#9](https://github.com/voxpupuli/puppet-cvmfs/pull/9) ([kreczko](https://github.com/kreczko))
+- Move yumrepos to seperate file to install.pp to allow cvmfs::server to reuse yumrepos. [\#7](https://github.com/voxpupuli/puppet-cvmfs/pull/7) ([traylenator](https://github.com/traylenator))
+- Tidying up meta data [\#5](https://github.com/voxpupuli/puppet-cvmfs/pull/5) ([kreczko](https://github.com/kreczko))
+- cvmfs 2.1 really is supported now. [\#3](https://github.com/voxpupuli/puppet-cvmfs/pull/3) ([traylenator](https://github.com/traylenator))
+- Module update + fixes [\#2](https://github.com/voxpupuli/puppet-cvmfs/pull/2) ([kreczko](https://github.com/kreczko))
+- text fixes [\#1](https://github.com/voxpupuli/puppet-cvmfs/pull/1) ([deesto](https://github.com/deesto))
+
+## [puppet-cvmfs-0.0.2](https://github.com/voxpupuli/puppet-cvmfs/tree/puppet-cvmfs-0.0.2) (2013-03-18)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/puppet-cvmfs-0.0.1...puppet-cvmfs-0.0.2)
+
+## [puppet-cvmfs-0.0.1](https://github.com/voxpupuli/puppet-cvmfs/tree/puppet-cvmfs-0.0.1) (2012-06-01)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cvmfs/compare/334613ae5fb3778beb132cb05ad6fd6b28ff1c02...puppet-cvmfs-0.0.1)
+
+
+
+\* *This Changelog was automatically generated by [github_changelog_generator](https://github.com/github-changelog-generator/github-changelog-generator)*

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-cvmfs",
-  "version": "7.3.1-rc0",
+  "version": "8.0.0",
   "summary": "Manages CVMFS clients",
   "author": "Vox Pupuli",
   "project_page": "https://github.com/voxpupuli/puppet-cvmfs",


### PR DESCRIPTION
#### Pull Request (PR) description

**Breaking changes:**

- Remove 'yum' string from class parameters [\#123](https://github.com/voxpupuli/puppet-cvmfs/pull/123) ([traylenator](https://github.com/traylenator))
- Add type enforcement to cvmfs::mount and cvmfs::domain [\#122](https://github.com/voxpupuli/puppet-cvmfs/pull/122) ([traylenator](https://github.com/traylenator))
- Drop all CvmFS server code [\#113](https://github.com/voxpupuli/puppet-cvmfs/pull/113) ([traylenator](https://github.com/traylenator))

**Implemented enhancements:**

- Add CVMFS\_IPFAMILY\_PREFER config parameter [\#125](https://github.com/voxpupuli/puppet-cvmfs/pull/125) ([luisfdez](https://github.com/luisfdez))
- Add ubuntu 18.04, 20.04 and debian 10 support [\#124](https://github.com/voxpupuli/puppet-cvmfs/pull/124) ([traylenator](https://github.com/traylenator))
- Convert main config template to epp [\#118](https://github.com/voxpupuli/puppet-cvmfs/pull/118) ([traylenator](https://github.com/traylenator))

**Fixed bugs:**

- cvmfs\_external\_url parameter to mount fixed [\#127](https://github.com/voxpupuli/puppet-cvmfs/pull/127) ([traylenator](https://github.com/traylenator))
- Correct parameter name for default case [\#126](https://github.com/voxpupuli/puppet-cvmfs/pull/126) ([traylenator](https://github.com/traylenator))

**Merged pull requests:**

- Update all documentation [\#128](https://github.com/voxpupuli/puppet-cvmfs/pull/128) ([traylenator](https://github.com/traylenator))
- Use modern splat rather than create resources [\#121](https://github.com/voxpupuli/puppet-cvmfs/pull/121) ([traylenator](https://github.com/traylenator))
- Whitespace, Automatic lint and Rubocop Fixes [\#114](https://github.com/voxpupuli/puppet-cvmfs/pull/114) ([traylenator](https://github.com/traylenator))
- Increase upper version of firewall module [\#112](https://github.com/voxpupuli/puppet-cvmfs/pull/112) ([sorrison](https://github.com/sorrison))
- cvmfs::install: Fact file creation must depend on Package\[cvmfs\]. [\#111](https://github.com/voxpupuli/puppet-cvmfs/pull/111) ([olifre](https://github.com/olifre))
- Add UID\_MAP and GID\_MAP functionality. [\#110](https://github.com/voxpupuli/puppet-cvmfs/pull/110) ([olifre](https://github.com/olifre))
- add missing package require for file ownership [\#104](https://github.com/voxpupuli/puppet-cvmfs/pull/104) ([fschaer](https://github.com/fschaer))
