### PR TITLE
cvmfspartsize fact return integer rather than string

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,4 +1,7 @@
 ---
+spec/spec_helper.rb:
+  mock_with: ':mocha'
+
 spec/spec_helper_acceptance.rb:
   unmanaged: false
 

--- a/lib/facter/cvmfspartsize.rb
+++ b/lib/facter/cvmfspartsize.rb
@@ -6,11 +6,12 @@
 
 require 'yaml'
 Facter.add(:cvmfspartsize) do
-  confine kernel: 'Linux'
+  @df_cmd = Facter::Util::Resolution.which('df')
+  confine { @df_cmd }
   setcode do
     if File.exist?('/etc/cvmfs/cvmfsfacts.yaml')
       directory = YAML.safe_load(File.open('/etc/cvmfs/cvmfsfacts.yaml'))['cvmfs_cache_base']
-      Facter::Util::Resolution.exec("/bin/df -m -P #{directory}").split("\n").last.split(%r{\s+})[1]
+      Facter::Core::Execution.execute(%(#{@df_cmd} -m -P #{directory})).split("\n").last.split(%r{\s+})[1].to_i
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,10 @@
 # https://github.com/voxpupuli/modulesync
 # https://github.com/voxpupuli/modulesync_config
 
+RSpec.configure do |c|
+  c.mock_with :mocha
+end
+
 # puppetlabs_spec_helper will set up coverage if the env variable is set.
 # We want to do this if lib exists and it hasn't been explicitly set.
 ENV['COVERAGE'] ||= 'yes' if Dir.exist?(File.expand_path('../../lib', __FILE__))

--- a/spec/unit/facter/cvmfspartsize_spec.rb
+++ b/spec/unit/facter/cvmfspartsize_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe 'cvmfspartsize' do
+  before do
+    Facter.clear
+    Facter::Util::Resolution.stubs(:which).with('df').returns('/usr/bin/df')
+    File.stubs(:exist?).with('/etc/cvmfs/cvmfsfacts.yaml').returns(true)
+    File.stubs(:open).with('/etc/cvmfs/cvmfsfacts.yaml').returns("---\ncvmfs_cache_base: /foo/bar\n")
+    Facter::Core::Execution.stubs(:execute).with('/usr/bin/df -m -P /foo/bar').returns(cvmfs_df_result)
+  end
+
+  context 'working case' do
+    let(:cvmfs_df_result) { "/dev/nvme0n1p5            976   251       659      28% /foo/bar\n" }
+
+    it 'returns valid fact' do
+      expect(Facter.fact('cvmfspartsize').value).to eq(976)
+    end
+  end
+
+  context 'config missing' do
+    let(:cvmfs_df_result) { :failed }
+
+    it 'does not return a fact' do
+      File.stubs(:exist?).with('/etc/cvmfs/cvmfsfacts.yaml').returns(false)
+      expect(Facter.fact('cvmfspartsize').value).to be_nil
+    end
+  end
+
+  context 'df fails' do
+    let(:cvmfs_df_result) { :failed }
+
+    it 'does not return a fact' do
+      Facter::Core::Execution.stubs(:execute).with('/usr/bin/df -m -P /foo/bar').returns(:failed)
+      expect(Facter.fact('cvmfspartsize').value).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
#### Pull Request (PR) description
The cvmfspartsize fact was returning a stringed integer
for a megabyte size.

This fact should return an integer.

#### This Pull Request (PR) fixes the following issues
Fixes #131
