### PR TITLE
Add configuration option for CVMFS_KEYS_DIR

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -645,6 +645,7 @@ The following parameters are available in the `cvmfs::domain` defined type:
 * [`cvmfs_external_timeout_direct`](#cvmfs_external_timeout_direct)
 * [`cvmfs_external_url`](#cvmfs_external_url)
 * [`cvmfs_public_key`](#cvmfs_public_key)
+* [`cvmfs_keys_dir`](#cvmfs_keys_dir)
 
 ##### <a name="domain"></a>`domain`
 
@@ -782,6 +783,14 @@ Specify repository signing key
 
 Default value: ``undef``
 
+##### <a name="cvmfs_keys_dir"></a>`cvmfs_keys_dir`
+
+Data type: `Optional[String[1]]`
+
+Specify directory with repository signing keys for domain
+
+Default value: ``undef``
+
 ### <a name="cvmfsid_map"></a>`cvmfs::id_map`
 
 Create a map file uid or gid mappings
@@ -849,6 +858,7 @@ The following parameters are available in the `cvmfs::mount` defined type:
 * [`cvmfs_timeout_direct`](#cvmfs_timeout_direct)
 * [`cvmfs_nfiles`](#cvmfs_nfiles)
 * [`cvmfs_public_key`](#cvmfs_public_key)
+* [`cvmfs_keys_dir`](#cvmfs_keys_dir)
 * [`cvmfs_max_ttl`](#cvmfs_max_ttl)
 * [`cvmfs_env_variables`](#cvmfs_env_variables)
 * [`cvmfs_use_geoapi`](#cvmfs_use_geoapi)
@@ -929,6 +939,14 @@ Default value: ``undef``
 Data type: `Optional[String[1]]`
 
 Public key of repository, sets CVMFS_PUBLIC_KEYS
+
+Default value: ``undef``
+
+##### <a name="cvmfs_keys_dir"></a>`cvmfs_keys_dir`
+
+Data type: `Optional[String[1]]`
+
+Directory with public keys of repository, sets CVMFS_KEYS_DIR
 
 Default value: ``undef``
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -785,7 +785,7 @@ Default value: ``undef``
 
 ##### <a name="cvmfs_keys_dir"></a>`cvmfs_keys_dir`
 
-Data type: `Optional[String[1]]`
+Data type: `Optional[Stdlib::Absolutepath]`
 
 Specify directory with repository signing keys for domain
 

--- a/manifests/domain.pp
+++ b/manifests/domain.pp
@@ -21,6 +21,7 @@
 # @param cvmfs_external_timeout_direct Sets CVMFS_EXTERNAL_TIMEOUT_DIRECT
 # @param cvmfs_external_url Sets CVMFS_EXTERNAL_URL
 # @param cvmfs_public_key Specify repository signing key
+# @param cvmfs_keys_dir Specify repository directory with signing keys
 #
 define cvmfs::domain (
   Stdlib::Fqdn $domain                             = $name,
@@ -31,6 +32,7 @@ define cvmfs::domain (
   Optional[Integer] $cvmfs_timeout_direct          = undef,
   Optional[Integer] $cvmfs_nfiles                  = undef,
   Optional[String[1]] $cvmfs_public_key            = undef,
+  Optional[String[1]] $cvmfs_keys_dir              = undef,
   Optional[Integer] $cvmfs_max_ttl                 = undef,
   Optional[Hash] $cvmfs_env_variables              = undef,
   Optional[Stdlib::Yes_no] $cvmfs_use_geoapi       = undef,
@@ -58,6 +60,7 @@ define cvmfs::domain (
         'cvmfs_timeout_direct'          => $cvmfs_timeout_direct,
         'cvmfs_nfiles'                  => $cvmfs_nfiles,
         'cvmfs_public_key'              => $cvmfs_public_key,
+        'cvmfs_keys_dir'                => $cvmfs_keys_dir,
         'cvmfs_max_ttl'                 => $cvmfs_max_ttl,
         'cvmfs_env_variables'           => $cvmfs_env_variables,
         'cvmfs_use_geoapi'              => $cvmfs_use_geoapi,

--- a/manifests/domain.pp
+++ b/manifests/domain.pp
@@ -32,7 +32,7 @@ define cvmfs::domain (
   Optional[Integer] $cvmfs_timeout_direct          = undef,
   Optional[Integer] $cvmfs_nfiles                  = undef,
   Optional[String[1]] $cvmfs_public_key            = undef,
-  Optional[String[1]] $cvmfs_keys_dir              = undef,
+  Optional[Stdlib::Absolutepath] $cvmfs_keys_dir   = undef,
   Optional[Integer] $cvmfs_max_ttl                 = undef,
   Optional[Hash] $cvmfs_env_variables              = undef,
   Optional[Stdlib::Yes_no] $cvmfs_use_geoapi       = undef,

--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -54,7 +54,7 @@ define cvmfs::mount (
   Optional[Integer] $cvmfs_timeout_direct                           = undef,
   Optional[Integer] $cvmfs_nfiles                                   = undef,
   Optional[String[1]] $cvmfs_public_key                             = undef,
-  Optional[String[1]] $cvmfs_keys_dir                               = undef,
+  Optional[Stdlib::Absolutepath] $cvmfs_keys_dir                    = undef,
   Optional[Integer] $cvmfs_max_ttl                                  = undef,
   Optional[Hash] $cvmfs_env_variables                               = undef,
   Optional[Stdlib::Yes_no] $cvmfs_use_geoapi                        = undef,

--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -25,6 +25,7 @@
 # @param cvmfs_timeout_direct Sets CVMFS_HTTP_TIMEOUT_DIRECT
 # @param cvmfs_nfiles Number of open files permitted on the OS. Sets CVMFS_NFILES
 # @param cvmfs_public_key Public key of repository, sets CVMFS_PUBLIC_KEYS
+# @param cvmfs_keys_dir Directory with publice keys for repository, sets CVMFS_KEYS_DIR
 # @param cvmfs_max_ttl Maximum effective TTL in seconds for DNS queries of proxy server names. Sets CVMFS_MAX_TTL
 # @param cvmfs_env_variables Sets per repo environments variables for magic links.
 # @param cvmfs_use_geoapi Set CVMFS_MAX_GEOAPI
@@ -53,6 +54,7 @@ define cvmfs::mount (
   Optional[Integer] $cvmfs_timeout_direct                           = undef,
   Optional[Integer] $cvmfs_nfiles                                   = undef,
   Optional[String[1]] $cvmfs_public_key                             = undef,
+  Optional[String[1]] $cvmfs_keys_dir                               = undef,
   Optional[Integer] $cvmfs_max_ttl                                  = undef,
   Optional[Hash] $cvmfs_env_variables                               = undef,
   Optional[Stdlib::Yes_no] $cvmfs_use_geoapi                        = undef,
@@ -97,6 +99,7 @@ define cvmfs::mount (
         'cvmfs_timeout_direct'          => $cvmfs_timeout_direct,
         'cvmfs_nfiles'                  => $cvmfs_nfiles,
         'cvmfs_public_key'              => $cvmfs_public_key,
+        'cvmfs_keys_dir'                => $cvmfs_keys_dir,
         'cvmfs_max_ttl'                 => $cvmfs_max_ttl,
         'cvmfs_env_variables'           => $cvmfs_env_variables,
         'cvmfs_use_geoapi'              => $cvmfs_use_geoapi,

--- a/spec/defines/domain_spec.rb
+++ b/spec/defines/domain_spec.rb
@@ -42,6 +42,13 @@ describe 'cvmfs::domain' do
             is_expected.to contain_file('/etc/cvmfs/domain.d/example.org.local').with('content' => %r{^CVMFS_QUOTA_LIMIT='12345'$})
           end
         end
+        context 'with cvmfs_keys_dir set' do
+          let(:params) { { cvmfs_keys_dir: '/etc/cvmfs/keys/example.org' } }
+
+          it do
+            is_expected.to contain_file('/etc/cvmfs/domain.d/example.org.local').with('content' => %r{^CVMFS_KEYS_DIR='/etc/cvmfs/keys/example.org'$})
+          end
+        end
       end
     end
   end

--- a/spec/defines/mount_spec.rb
+++ b/spec/defines/mount_spec.rb
@@ -45,6 +45,7 @@ describe 'cvmfs::mount' do
               cvmfs_uid_map: { 123 => 12 },
               cvmfs_gid_map: { 137 => 42 },
               cvmfs_quota_limit: 54_321,
+              cvmfs_keys_dir: '/etc/cvmfs/keys/example.org',
               cvmfs_external_fallback_proxy: 'http://external-fallback.example.org:3128',
               cvmfs_external_http_proxy: 'http://http-proxy.example.org:2138',
               cvmfs_external_timeout: 100,
@@ -61,6 +62,7 @@ describe 'cvmfs::mount' do
           it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').with('content' => %r{^CVMFS_UID_MAP='/etc/cvmfs/config.d/files.example.org.uid_map'$}) }
           it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').with('content' => %r{^CVMFS_GID_MAP='/etc/cvmfs/config.d/files.example.org.gid_map'$}) }
           it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').with('content' => %r{^CVMFS_QUOTA_LIMIT='54321'$}) }
+          it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').with('content' => %r{^CVMFS_KEYS_DIR='/etc/cvmfs/keys/example.org'$}) }
           it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').with('content' => %r{^CVMFS_EXTERNAL_FALLBACK_PROXY='http://external-fallback.example.org:3128'$}) }
           it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').with('content' => %r{^CVMFS_EXTERNAL_HTTP_PROXY='http://http-proxy.example.org:2138'$}) }
           it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').with('content' => %r{^CVMFS_EXTERNAL_TIMEOUT='100'$}) }

--- a/templates/repo.local.epp
+++ b/templates/repo.local.epp
@@ -16,6 +16,7 @@
   Optional[Integer[0]]                         $cvmfs_timeout_direct = undef,
   Optional[Integer[1]]                         $cvmfs_nfiles = undef,
   Optional[String[1]]                          $cvmfs_public_key = undef,
+  Optional[String[1]]                          $cvmfs_keys_dir = undef,
   Optional[Integer[0,1]]                       $cvmfs_syslog_level = undef,
   Optional[Stdlib::Unixpath]                   $cvmfs_tracefile = undef,
   Optional[Stdlib::Unixpath]                   $cvmfs_debuglog = undef,
@@ -88,6 +89,9 @@ CVMFS_NFILES='<%= $cvmfs_nfiles %>'
 <% } -%>
 <% if $cvmfs_public_key { -%>
 CVMFS_PUBLIC_KEY='<%= $cvmfs_public_key %>'
+<% } -%>
+<% if $cvmfs_keys_dir { -%>
+CVMFS_KEYS_DIR='<%= $cvmfs_keys_dir %>'
 <% } -%>
 <% if $cvmfs_syslog_level { -%>
 CVMFS_SYSLOG_LEVEL='<%= $cvmfs_syslog_level %>'


### PR DESCRIPTION
#### Pull Request (PR) description

Add support for CVMFS_KEYS_DIR configuration option which is necessary in case repositories configured by `domain.d` (`cvmfs_domain_hash`) doesn't share same key.