### PR TITLE
install: Require apt::update before package installation.

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -15,6 +15,8 @@ class cvmfs::install (
       'Debian': {
         contain 'cvmfs::apt'
         Class['cvmfs::apt'] -> Package['cvmfs']
+        # Needed since apt::update is only notified in apt::source, but not contained.
+        Class['apt::update'] -> Package['cvmfs']
       }
       default: { fail('Only repositories for RedHat or Debian family can be managed') }
     }


### PR DESCRIPTION
#### Pull Request (PR) description

This is needed since while `cvmfs::apt` contains `apt::source`, `apt::source` only notifies `apt:update`, but does not contain it.

#### This Pull Request (PR) fixes the following issues

This fixes an error on the very first Puppet run on Debian / Ubuntu based systems (repository source was added, but `apt::update` may have been called too late). 