### PR TITLE
limits, file_concat and firewall fixtures not required

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,9 +4,6 @@ fixtures:
     apt: https://github.com/puppetlabs/puppetlabs-apt.git
     systemd: https://github.com/camptocamp/puppet-systemd.git
     concat: https://github.com/puppetlabs/puppetlabs-concat.git
-    firewall: https://github.com/puppetlabs/puppetlabs-firewall.git
-    limits: https://github.com/erwbgy/puppet-limits.git
-    file_concat: git://github.com/electrical/puppet-lib-file_concat.git
     yumrepo_core: https://github.com/puppetlabs/puppetlabs-yumrepo_core.git
     cron_core: https://github.com/puppetlabs/puppetlabs-cron_core.git
     augeas_core: https://github.com/puppetlabs/puppetlabs-augeas_core.git

--- a/metadata.json
+++ b/metadata.json
@@ -22,10 +22,6 @@
     {
       "version_requirement": ">= 4.13.1 < 9.0.0",
       "name": "puppetlabs/stdlib"
-    },
-    {
-      "version_requirement": ">=1.0.0 < 4.0.0",
-      "name": "puppetlabs/firewall"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
#### Pull Request (PR) description
Since the cvmfs server configuration was removed in
https://github.com/voxpupuli/puppet-cvmfs/pull/113
the firewall, file_concat and limits puppet module are no longer
used.