### PR TITLE
Line not commented in auto.master configuration

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -169,7 +169,7 @@ class cvmfs::config (
     } else {
       file { '/etc/auto.master.d/cvmfs.autofs':
         ensure  => file,
-        content => "Puppet installed\n/cvmfs  program:/etc/auto.cvmfs\n",
+        content => "# Puppet installed\n/cvmfs  program:/etc/auto.cvmfs\n",
         owner   => root,
         group   => root,
         mode    => '0644',


### PR DESCRIPTION
#### Pull Request (PR) description

automount was starting with

```
syntax error in map near [ Puppet installed ]
```

In reality had no impact