### PR TITLE
Do not run fsck if no mount has occurred

### DIFF
--- a/templates/fsck/cvmfs-fsck.service.epp
+++ b/templates/fsck/cvmfs-fsck.service.epp
@@ -6,6 +6,7 @@
 
 [Unit]
 Description=cvmfs fsck
+ConditionPathExists=<%= $cache_base %>/shared/txn
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
#### Pull Request (PR) description

When no single cvmfs mount has been mounted on a fresh node the directory
`/var/lib/cvmfs/shared/txn` does not exist and the cvmfs-fsck.service
fails.

Suppress the fsck unit until the directory exists.


