### PR TITLE
acceptance tests: os.distro fact requires lsb-release on Debian

### DIFF
--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -1,0 +1,7 @@
+# Needed for os.distro.codebase fact
+if $facts['os']['name'] == 'Ubuntu' and $facts['os']['release']['full'] == '18.04' and versioncmp($facts['puppetversion'], '7') <= 0 {
+  package{'lsb-release':
+    ensure => present,
+  }
+}
+


### PR DESCRIPTION
#### Pull Request (PR) description
Acceptance tests for Ubuntu 18.04 started to fail
as presumably lsb-release has gone from the image.

Install it explicitly for testing.

