### PR TITLE
Enforce new enough puppetlabs-stdlib for  Stdlib::Yes_no

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -20,7 +20,7 @@
       "name": "puppetlabs/concat"
     },
     {
-      "version_requirement": ">= 4.13.1 < 9.0.0",
+      "version_requirement": ">= 6.1.0 < 9.0.0",
       "name": "puppetlabs/stdlib"
     }
   ],


### PR DESCRIPTION
#### This Pull Request (PR) fixes the following issues
Templates now use `Stdlib::Yes_no` and so minimum version
of puppetlabs-stdlib must be increased.

#### Pull Request (PR) description
Fixes #149

