### PR TITLE
fsck: cvmfs-fsck.timer depends on cvmfs-fsck.service.

### DIFF
--- a/manifests/fsck.pp
+++ b/manifests/fsck.pp
@@ -19,22 +19,18 @@ class cvmfs::fsck (
   }
 
   if $_usesystemd {
-    systemd::unit_file { 'cvmfs-fsck.timer':
-      ensure  => present,
-      content => epp('cvmfs/fsck/cvmfs-fsck.timer.epp',
-        {
-          'onreboot' => $onreboot,
-      }),
-      enable  => true,
-      active  => true,
-    }
-    systemd::unit_file { 'cvmfs-fsck.service':
-      ensure  => present,
-      content => epp('cvmfs/fsck/cvmfs-fsck.service.epp',
+    systemd::timer { 'cvmfs-fsck.timer':
+      service_content => epp('cvmfs/fsck/cvmfs-fsck.service.epp',
         {
           'cache_base' => $cvmfs_cache_base,
           'options'    => $options,
       }),
+      timer_content   => epp('cvmfs/fsck/cvmfs-fsck.timer.epp',
+        {
+          'onreboot' => $onreboot,
+      }),
+      enable          => true,
+      active          => true,
     }
     systemd::tmpfile { 'cvmfs-quarantaine.conf':
       content => epp('cvmfs/fsck/cvmfs-quarantaine.conf.epp',

--- a/spec/classes/fsck_spec.rb
+++ b/spec/classes/fsck_spec.rb
@@ -22,17 +22,16 @@ describe 'cvmfs::fsck' do
           it { is_expected.to contain_cron('clean_quarantaine') }
           it { is_expected.to contain_cron('cvmfs_fsck') }
           it { is_expected.not_to contain_systemd__tmpfile('cvmfs-quarantaine.conf') }
-          it { is_expected.not_to contain_systemd__unit_file('cvmfs-fsck.service') }
-          it { is_expected.not_to contain_systemd__unit_file('cvmfs-fsck.timer') }
+          it { is_expected.not_to contain_systemd__timer('cvmfs-fsck.timer') }
         else
           it { is_expected.not_to contain_file('/usr/local/sbin/cvmfs_fsck_cron.sh') }
           it { is_expected.not_to contain_cron('clean_quarantaine') }
           it { is_expected.not_to contain_cron('cvmfs_fsck') }
           it { is_expected.to contain_systemd__tmpfile('cvmfs-quarantaine.conf').with_content(%r{d /var/lib/cvmfs/shared/quarantaine 0700 cvmfs cvmfs 30d}) }
-          it { is_expected.to contain_systemd__unit_file('cvmfs-fsck.service').with_content(%r{^ExecStart=/usr/bin/cvmfs_fsck  /var/lib/cvmfs/shared$}) }
-          it { is_expected.to contain_systemd__unit_file('cvmfs-fsck.service').with_content(%r{^ConditionPathExists=/var/lib/cvmfs/shared/txn$}) }
-          it { is_expected.to contain_systemd__unit_file('cvmfs-fsck.timer').with_content(%r{^OnUnitActiveSec=1week$}) }
-          it { is_expected.to contain_systemd__unit_file('cvmfs-fsck.timer').without_content(%r{^OnBootSec$}) }
+          it { is_expected.to contain_systemd__timer('cvmfs-fsck.timer').with_service_content(%r{^ExecStart=/usr/bin/cvmfs_fsck  /var/lib/cvmfs/shared$}) }
+          it { is_expected.to contain_systemd__timer('cvmfs-fsck.timer').with_service_content(%r{^ConditionPathExists=/var/lib/cvmfs/shared/txn$}) }
+          it { is_expected.to contain_systemd__timer('cvmfs-fsck.timer').with_timer_content(%r{^OnUnitActiveSec=1week$}) }
+          it { is_expected.to contain_systemd__timer('cvmfs-fsck.timer').without_timer_content(%r{^OnBootSec$}) }
         end
       end
 
@@ -48,7 +47,7 @@ describe 'cvmfs::fsck' do
           it { is_expected.to contain_cron('cvmfs_fsck_on_reboot') }
         else
           it { is_expected.not_to contain_cron('cvmfs_fsck_on_reboot') }
-          it { is_expected.to contain_systemd__unit_file('cvmfs-fsck.timer').with_content(%r{^OnBootSec=5min$}) }
+          it { is_expected.to contain_systemd__timer('cvmfs-fsck.timer').with_timer_content(%r{^OnBootSec=5min$}) }
         end
       end
 
@@ -63,7 +62,7 @@ describe 'cvmfs::fsck' do
         when '6', '7'
           it { is_expected.not_to contain_cron('cvmfs_fsck_on_reboot') }
         else
-          it { is_expected.to contain_systemd__unit_file('cvmfs-fsck.timer').with_content(%r{^OnUnitActiveSec=1week$}) }
+          it { is_expected.to contain_systemd__timer('cvmfs-fsck.timer').with_timer_content(%r{^OnUnitActiveSec=1week$}) }
         end
       end
 
@@ -79,8 +78,8 @@ describe 'cvmfs::fsck' do
         when '6', '7'
           it { is_expected.to contain_file('/usr/local/sbin/cvmfs_fsck_cron.sh').with_content(%r{\s* nice ionice -c3 /usr/bin/cvmfs_fsck -p /foo/shared$}) }
         else
-          it { is_expected.to contain_systemd__unit_file('cvmfs-fsck.service').with_content(%r{^ExecStart=/usr/bin/cvmfs_fsck -p /foo/shared$}) }
-          it { is_expected.to contain_systemd__unit_file('cvmfs-fsck.service').with_content(%r{^ConditionPathExists=/foo/shared/txn$}) }
+          it { is_expected.to contain_systemd__timer('cvmfs-fsck.timer').with_service_content(%r{^ExecStart=/usr/bin/cvmfs_fsck -p /foo/shared$}) }
+          it { is_expected.to contain_systemd__timer('cvmfs-fsck.timer').with_service_content(%r{^ConditionPathExists=/foo/shared/txn$}) }
         end
       end
     end


### PR DESCRIPTION
#### Pull Request (PR) description
`cvmfs-fsck.timer` should depend on `cvmfs-fsck.service`, otherwise they may be instantiated in different order. 

#### This Pull Request (PR) fixes the following issues
Without this dependency, the error message:
```
cvmfs-fsck.timer: Refusing to start, unit cvmfs-fsck.service to trigger not loaded.
```
may appear during the first Puppet run, depending on resource evaluation order.
