### PR TITLE
Check that cvmfs_cache_base directory exists

### DIFF
--- a/lib/facter/cvmfspartsize.rb
+++ b/lib/facter/cvmfspartsize.rb
@@ -13,7 +13,9 @@ Facter.add(:cvmfspartsize) do
   setcode do
     if File.exist?('/etc/cvmfs/cvmfsfacts.yaml')
       directory = YAML.safe_load(File.open('/etc/cvmfs/cvmfsfacts.yaml'))['cvmfs_cache_base']
-      Facter::Core::Execution.execute(%(#{@df_cmd} -m -P #{directory})).split("\n").last.split(%r{\s+})[1].to_i
+      if File.exist?(directory)
+        Facter::Core::Execution.execute(%(#{@df_cmd} -m -P #{directory})).split("\n").last.split(%r{\s+})[1].to_i
+      end
     end
   end
 end

--- a/lib/facter/cvmfspartsize.rb
+++ b/lib/facter/cvmfspartsize.rb
@@ -13,9 +13,7 @@ Facter.add(:cvmfspartsize) do
   setcode do
     if File.exist?('/etc/cvmfs/cvmfsfacts.yaml')
       directory = YAML.safe_load(File.open('/etc/cvmfs/cvmfsfacts.yaml'))['cvmfs_cache_base']
-      if File.exist?(directory)
-        Facter::Core::Execution.execute(%(#{@df_cmd} -m -P #{directory})).split("\n").last.split(%r{\s+})[1].to_i
-      end
+      Facter::Core::Execution.execute(%(#{@df_cmd} -m -P #{directory})).split("\n").last.split(%r{\s+})[1].to_i if File.exist?(directory)
     end
   end
 end


### PR DESCRIPTION
If cvmfs has been installed but never mounted/used, it will not, triggering the following error:
```Error: Facter: Error while resolving custom fact fact='cvmfspartsize', resolution='<anonymous>': undefined method `split' for nil:NilClass```

#### Pull Request (PR) description

Fix facter error when cvmfs has been installed but never mounted.

#### This Pull Request (PR) fixes the following issues
Fixes #153 