### PR TITLE
Check that cvmfs_cache_base directory exists

### DIFF
--- a/lib/facter/cvmfspartsize.rb
+++ b/lib/facter/cvmfspartsize.rb
@@ -13,7 +13,7 @@ Facter.add(:cvmfspartsize) do
   setcode do
     if File.exist?('/etc/cvmfs/cvmfsfacts.yaml')
       directory = YAML.safe_load(File.open('/etc/cvmfs/cvmfsfacts.yaml'))['cvmfs_cache_base']
-      Facter::Core::Execution.execute(%(#{@df_cmd} -m -P #{directory})).split("\n").last.split(%r{\s+})[1].to_i
+      Facter::Core::Execution.execute(%(#{@df_cmd} -m -P #{directory})).split("\n").last.split(%r{\s+})[1].to_i if File.exist?(directory)
     end
   end
 end

--- a/spec/unit/facter/cvmfspartsize_spec.rb
+++ b/spec/unit/facter/cvmfspartsize_spec.rb
@@ -12,6 +12,10 @@ describe 'cvmfspartsize' do
   end
 
   context 'working case' do
+    before do
+      File.stubs(:exist?).with('/foo/bar').returns(true)
+    end
+
     let(:cvmfs_df_result) { "/dev/nvme0n1p5            976   251       659      28% /foo/bar\n" }
 
     it 'returns valid fact' do
@@ -29,6 +33,10 @@ describe 'cvmfspartsize' do
   end
 
   context 'df fails' do
+    before do
+      File.stubs(:exist?).with('/foo/bar').returns(false)
+    end
+
     let(:cvmfs_df_result) { :failed }
 
     it 'does not return a fact' do


### PR DESCRIPTION
If cvmfs has been installed but never mounted/used, it will not, triggering the following error:
```Error: Facter: Error while resolving custom fact fact='cvmfspartsize', resolution='<anonymous>': undefined method `split' for nil:NilClass```

#### Pull Request (PR) description

Fix facter error when cvmfs has been installed but never mounted.

#### This Pull Request (PR) fixes the following issues
Fixes https://github.com/voxpupuli/puppet-cvmfs/issues/153

#### Other

This PR is an attempt to unstick : https://github.com/voxpupuli/puppet-cvmfs/pull/154
