### PR TITLE
Stop creating quarentain directory

### DIFF
--- a/manifests/fsck.pp
+++ b/manifests/fsck.pp
@@ -35,11 +35,10 @@ class cvmfs::fsck (
       enable          => true,
       active          => true,
     }
+
+    # This removal of a now redundant can be removed at some future date
     systemd::tmpfile { 'cvmfs-quarantaine.conf':
-      content => epp('cvmfs/fsck/cvmfs-quarantaine.conf.epp',
-        {
-          'cache_base' => $cvmfs_cache_base,
-      }),
+      ensure  => absent,
     }
   } else {
     file { '/usr/local/sbin/cvmfs_fsck_cron.sh':

--- a/spec/classes/fsck_spec.rb
+++ b/spec/classes/fsck_spec.rb
@@ -27,7 +27,7 @@ describe 'cvmfs::fsck' do
           it { is_expected.not_to contain_file('/usr/local/sbin/cvmfs_fsck_cron.sh') }
           it { is_expected.not_to contain_cron('clean_quarantaine') }
           it { is_expected.not_to contain_cron('cvmfs_fsck') }
-          it { is_expected.to contain_systemd__tmpfile('cvmfs-quarantaine.conf').with_content(%r{d /var/lib/cvmfs/shared/quarantaine 0700 cvmfs cvmfs 30d}) }
+          it { is_expected.to contain_systemd__tmpfile('cvmfs-quarantaine.conf').with_ensure('absent') }
           it { is_expected.to contain_systemd__timer('cvmfs-fsck.timer').with_service_content(%r{^ExecStart=/usr/bin/cvmfs_fsck  /var/lib/cvmfs/shared$}) }
           it { is_expected.to contain_systemd__timer('cvmfs-fsck.timer').with_service_content(%r{^ConditionPathExists=/var/lib/cvmfs/shared/txn$}) }
           it { is_expected.to contain_systemd__timer('cvmfs-fsck.timer').with_timer_content(%r{^OnUnitActiveSec=1week$}) }

--- a/templates/fsck/cvmfs-quarantaine.conf.epp
+++ b/templates/fsck/cvmfs-quarantaine.conf.epp
@@ -1,6 +1,0 @@
-<%-|
-  String[1] $cache_base,
-|-%>
-# installed with puppet
-d <%= $cache_base %>/shared/quarantaine 0700 cvmfs cvmfs 30d
-


### PR DESCRIPTION
#### Pull Request (PR) description

This puppet module used to create the directory
`/var/lib/cvmfs/shared/quarentain`.

With systemd on EL9 this now produces the warning:

```
Detected unsafe path transition /var/lib/cvmfs (owned by cvmfs) → /var/lib/cvmfs/shared (owned by root) during canonicalization of /var/lib/cvmfs/shared
```

when the directory is created before `/var/lib/cvmfs/shared` has been created by CvmFS.

In reality this creation is no longer needed since CvmFS itself now creates both the `/var/lib/cvmfs/shared` and `/var/lib/cvmfs/shared/quarentaine` directories with correct ownership and permissions on first mount. This used to not be the case which is why the tmpfiles.d entry was present.
