### PR TITLE
Permit alternate uid/gid/mode for CVMFS cache

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -91,6 +91,9 @@ The following parameters are available in the `cvmfs` class:
 * [`cvmfs_quota_ratio`](#-cvmfs--cvmfs_quota_ratio)
 * [`cvmfs_http_proxy`](#-cvmfs--cvmfs_http_proxy)
 * [`cvmfs_cache_base`](#-cvmfs--cvmfs_cache_base)
+* [`cvmfs_cache_owner`](#-cvmfs--cvmfs_cache_owner)
+* [`cvmfs_cache_group`](#-cvmfs--cvmfs_cache_group)
+* [`cvmfs_cache_mode`](#-cvmfs--cvmfs_cache_mode)
 * [`cvmfs_ipfamily_prefer`](#-cvmfs--cvmfs_ipfamily_prefer)
 * [`cvmfs_dns_min_ttl`](#-cvmfs--cvmfs_dns_min_ttl)
 * [`cvmfs_dns_max_ttl`](#-cvmfs--cvmfs_dns_max_ttl)
@@ -191,6 +194,30 @@ Data type: `Stdlib::Absolutepath`
 Location of the CVMFS cache base
 
 Default value: `'/var/lib/cvmfs'`
+
+##### <a name="-cvmfs--cvmfs_cache_owner"></a>`cvmfs_cache_owner`
+
+Data type: `String[1]`
+
+expected owner of cvmfs cache
+
+Default value: `'cvmfs'`
+
+##### <a name="-cvmfs--cvmfs_cache_group"></a>`cvmfs_cache_group`
+
+Data type: `String[1]`
+
+expected group of cvmfs cache
+
+Default value: `'cvmfs'`
+
+##### <a name="-cvmfs--cvmfs_cache_mode"></a>`cvmfs_cache_mode`
+
+Data type: `Stdlib::Filemode`
+
+expected mode of cvmfs cache
+
+Default value: `'0700'`
 
 ##### <a name="-cvmfs--cvmfs_ipfamily_prefer"></a>`cvmfs_ipfamily_prefer`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,6 +45,9 @@
 #   pre-allocated a partition to the cvmfs cache or else it makes little sense.
 # @param cvmfs_http_proxy List of squid servers, e.g `http://squid1.example.org;http;//squid2.example.org`
 # @param cvmfs_cache_base Location of the CVMFS cache base
+# @param cvmfs_cache_owner expected owner of cvmfs cache
+# @param cvmfs_cache_group expected group of cvmfs cache
+# @param cvmfs_cache_mode  expected mode of cvmfs cache
 # @param cvmfs_ipfamily_prefer Preferred IP protocol for dual-stack proxies. If not set, cvmfs default will be used.
 # @param cvmfs_dns_min_ttl Minimum ttl of DNS lookups in seconds.
 # @param cvmfs_dns_max_ttl Maximum ttl of DNS lookups in seconds.
@@ -114,6 +117,9 @@ class cvmfs (
   Variant[Enum['auto'],Integer] $cvmfs_quota_limit                    = 1000,
   Float   $cvmfs_quota_ratio                                          = 0.85,
   Stdlib::Absolutepath $cvmfs_cache_base                              = '/var/lib/cvmfs',
+  String[1] $cvmfs_cache_owner                                        = 'cvmfs',
+  String[1] $cvmfs_cache_group                                        = 'cvmfs',
+  Stdlib::Filemode $cvmfs_cache_mode                                         = '0700',
   Optional[Enum['yes','no']] $cvmfs_claim_ownership                   = undef,
   Optional[Hash[Variant[Integer,String], Integer, 1]] $cvmfs_uid_map  = undef,
   Optional[Hash[Variant[Integer,String], Integer, 1]] $cvmfs_gid_map  = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -119,7 +119,7 @@ class cvmfs (
   Stdlib::Absolutepath $cvmfs_cache_base                              = '/var/lib/cvmfs',
   String[1] $cvmfs_cache_owner                                        = 'cvmfs',
   String[1] $cvmfs_cache_group                                        = 'cvmfs',
-  Stdlib::Filemode $cvmfs_cache_mode                                         = '0700',
+  Stdlib::Filemode $cvmfs_cache_mode                                  = '0700',
   Optional[Enum['yes','no']] $cvmfs_claim_ownership                   = undef,
   Optional[Hash[Variant[Integer,String], Integer, 1]] $cvmfs_uid_map  = undef,
   Optional[Hash[Variant[Integer,String], Integer, 1]] $cvmfs_gid_map  = undef,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -33,9 +33,9 @@ class cvmfs::install (
   if $cvmfs_cache_base != $default_cvmfs_cache_base {
     file { $cvmfs_cache_base:
       ensure  => directory,
-      owner   => cvmfs,
-      group   => cvmfs,
-      mode    => '0700',
+      owner   => $cvmfs::cvmfs_cache_owner,
+      group   => $cvmfs::cvmfs_cache_group,
+      mode    => $cvmfs::cvmfs_cache_mode,
       seltype => $cache_seltype,
       require => Package['cvmfs'],
     }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -497,6 +497,17 @@ describe 'cvmfs' do
             end
           end
 
+          context 'cvmfs_cache_base set to non-defaults' do
+            let(:params) do
+              super().merge(cvmfs_cache_base: '/unit/test',
+                            cvmfs_cache_owner: 'unit',
+                            cvmfs_cache_group: 'test',
+                            cvmfs_cache_mode: '0777')
+            end
+
+            it { is_expected.to contain_file('/unit/test').with_owner('unit').with_group('test').with_mode('0777').with_seltype('cvmfs_cache_t') }
+          end
+
           context 'with cvmfs_domain_hash set' do
             let(:params) do
               super().merge(cvmfs_domain_hash: {


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
This permits using a non-hardcoded owner/group/mode for the cvmfs cache

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
