### PR TITLE
RockyLinux 8 and 9 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -55,7 +55,13 @@
         "9"
       ]
     },
-
+    {
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": [
+        "8",
+        "9"
+      ]
+    },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [


### PR DESCRIPTION
#### Pull Request (PR) description
Declare support for "new" OSes:
* Rocky Linux 8 and 9

This is basically a follow-up to #169 , we are using CVMFS via this module on Rocky 8 in production since quite a while, and given the large [world-wide adoption](https://www.phoronix.com/news/EPEL-Stats-Rocky-Linux-Surge) of Rocky, it seems reasonable to also support this fork. 