### PR TITLE
Use cvmfs_partsize as an integer in tests

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -66,7 +66,7 @@ describe 'cvmfs' do
 
         context 'with defaults and cvmfspartsize fact set' do
           let(:facts) do
-            facts.merge(cvmfspartsize: '10000000')
+            facts.merge(cvmfspartsize: 10_000_000)
           end
 
           it { is_expected.to compile.with_all_deps }


### PR DESCRIPTION
#### Pull Request (PR) description

The rspec tests were setting the `cvmfs_partsize` fact as a string despite it being an integer for years.

Resolves:
```
Puppet::PreformattedError:
Evaluation Error: The string '10000000' was automatically coerced to the numerical value 10000000
```

My first Puppet 8 bug fixed.
