### PR TITLE
Support configuration repositories when using mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,16 @@ cvmfs::domain{'example.net'
 
 To use puppet's mount type rather that autofs
 a typical configuration might be the following. This
-examples configures a cvmfs domain, a configuration
+example configures a cvmfs domain for common settings, a configuration
 repository and finally a particular repository for
-mount.
+mount. In this example the `cvmfs-config.example.org` has
+been marked as the per client configuration repository and will always
+be mounted first.
 
 ```puppet
 class{'cvmfs':
   mount_method => 'mount',
+  config_repo  => 'cvmfs-config.example.org',
 }
 cvmfs::domain{'example.org':
   cvmfs_server_url   => 'http://web.example.org/cvmfs/@fqrn@'

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -109,6 +109,7 @@ class{'cvmfs':
 The following parameters are available in the `cvmfs` class:
 
 * [`mount_method`](#-cvmfs--mount_method)
+* [`config_repo`](#-cvmfs--config_repo)
 * [`manage_autofs_service`](#-cvmfs--manage_autofs_service)
 * [`cvmfs_quota_limit`](#-cvmfs--cvmfs_quota_limit)
 * [`cvmfs_quota_ratio`](#-cvmfs--cvmfs_quota_ratio)
@@ -186,6 +187,17 @@ use puppet's mount type, currently adding a line to /etc/fstab. The *none* optio
 skips all mounting.  Note that migrating between for instance *autofs* and then *mount* is not supported.
 
 Default value: `'autofs'`
+
+##### <a name="-cvmfs--config_repo"></a>`config_repo`
+
+Data type: `Optional[Stdlib::Fqdn]`
+
+When using the `mount_method` as `mount` it may be nescessary to specify a CvmFS located configuration_repository.
+This is a repository containing extra cvmfs configuration required to be mounted before any other
+repositories. There is at most one config_repo client. In addition the config_repo must actually be mounted
+explicitly with a `cvmfs::mount{$config_repo:}`, this is **not** automatic.
+
+Default value: `undef`
 
 ##### <a name="-cvmfs--manage_autofs_service"></a>`manage_autofs_service`
 
@@ -961,6 +973,27 @@ cvmfs::mount{'foobar.example.org':
 }
 ```
 
+##### Mount a repository with mount (not automount)
+
+```puppet
+class{ 'cvmfs':
+  mount_method => 'mount',
+}
+cvmfs::mount{'quark.example.org':}
+```
+
+##### Mount a repository with mount and a config_repo as well.
+
+```puppet
+
+class{ 'cvmfs':
+  mount_method => 'mount',
+  config_mount => 'cvmfs-config.example.org',
+}
+cvmfs::mount{'cvmfs-config.example.org':}
+cvmfs::mount{'down.example.org':}
+```
+
 #### Parameters
 
 The following parameters are available in the `cvmfs::mount` defined type:
@@ -1091,11 +1124,11 @@ Default value: `undef`
 
 ##### <a name="-cvmfs--mount--mount_method"></a>`mount_method`
 
-Data type: `Enum['autofs','mount','none']`
+Data type: `Optional[String[1]]`
 
-Should the mount attempt be made with autofs or tranditional fstab mount. Do no use this.
+Deprecated, do not set this, set mount_method for the whole client only on the main class.
 
-Default value: `$cvmfs::mount_method`
+Default value: `undef`
 
 ##### <a name="-cvmfs--mount--cvmfs_repo_list"></a>`cvmfs_repo_list`
 
@@ -1203,9 +1236,9 @@ Default value: `undef`
 
 ##### <a name="-cvmfs--mount--mount_options"></a>`mount_options`
 
-Data type: `String[1]`
+Data type: `Variant[String[1],Array[String[1]]]`
 
-Mount options to use for fstab style mounting.
+Mount options to use for fstab style mounting. mount_method==mount only
 
-Default value: `'defaults,_netdev,nodev'`
+Default value: `['defaults','_netdev','nodev']`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -8,12 +8,12 @@
 
 #### Public Classes
 
-* [`cvmfs`](#cvmfs): Installs and Configures CvmFS
+* [`cvmfs`](#cvmfs): Installs and Configures CVMFS
 
 #### Private Classes
 
 * `cvmfs::apt`: Configure cvmfs apt repositories
-* `cvmfs::config`: Central configuration of CvmFS
+* `cvmfs::config`: Central configuration of CVMFS
 * `cvmfs::fsck`: enable check_fsck as a cron or systemd timer
 * `cvmfs::install`: Install cvmfs from a yum repository.
 * `cvmfs::service`: Manages the cvmfs services. Opionally this also manages the autofs services
@@ -89,7 +89,7 @@ class{'cvmfs':
 }
 ```
 
-##### New parameters with CvmFS 2.11.0
+##### New parameters with CVMFS 2.11.0
 
 ```puppet
 class{'cvmfs':
@@ -192,7 +192,7 @@ Default value: `'autofs'`
 
 Data type: `Optional[Stdlib::Fqdn]`
 
-When using the `mount_method` as `mount` it may be nescessary to specify a CvmFS located configuration_repository.
+When using the `mount_method` as `mount` it may be nescessary to specify a CVMFS located configuration_repository.
 This is a repository containing extra cvmfs configuration required to be mounted before any other
 repositories. There is at most one config_repo client. In addition the config_repo must actually be mounted
 explicitly with a `cvmfs::mount{$config_repo:}`, this is **not** automatic.
@@ -578,7 +578,7 @@ Default value: `false`
 Data type: `Optional[Boolean]`
 
 Install or disable fuse3 variant of cvmfs, if left `undef` no change will be made. Note that changing
-this value when CvmFS mounts are active may well destroy those mounts.
+this value when CVMFS mounts are active may well destroy those mounts.
 Not availabe on Ubuntu 18.04.
 
 Default value: `undef`
@@ -778,7 +778,7 @@ The following parameters are available in the `cvmfs::domain` defined type:
 
 Data type: `Stdlib::Fqdn`
 
-The domain of CvmFS repositories to mount
+The domain of CVMFS repositories to mount
 
 Default value: `$name`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,4 +1,4 @@
-# @summary Central configuration of CvmFS
+# @summary Central configuration of CVMFS
 # @api private
 #
 class cvmfs::config (

--- a/manifests/domain.pp
+++ b/manifests/domain.pp
@@ -4,7 +4,7 @@
 #    cvmfs_server_url = 'http://example.org/cvmfs/@fqrn@',
 #  }
 #
-# @param domain The domain of CvmFS repositories to mount
+# @param domain The domain of CVMFS repositories to mount
 # @param cvmfs_quota_limit Per mount quota limit, not relavent to shared cache. Sets cvmfs_quota_limit
 # @param cvmfs_server_url Stratum 1 list, typically `;` delimited. Sets CVMFS_SERVER_URL parameter.
 # @param cvmfs_http_proxy List of http proxies to use. Sets CVMFS_PROXY_LIST parameter.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,4 +1,4 @@
-# @summary Installs and Configures CvmFS
+# @summary Installs and Configures CVMFS
 #
 # @see https://cvmfs.readthedocs.io/en/stable/apx-parameters.html CVMFS configuration parameters
 #
@@ -38,7 +38,7 @@
 #     }
 #   }
 #
-# @example New parameters with CvmFS 2.11.0
+# @example New parameters with CVMFS 2.11.0
 #  class{'cvmfs':
 #    cvmfs_cache_symlinks => 'yes',
 #    cvmfs_streaming_cache => 'no',
@@ -55,7 +55,7 @@
 #    use puppet's mount type, currently adding a line to /etc/fstab. The *none* option
 #    skips all mounting.  Note that migrating between for instance *autofs* and then *mount* is not supported.
 # @param config_repo
-#    When using the `mount_method` as `mount` it may be nescessary to specify a CvmFS located configuration_repository.
+#    When using the `mount_method` as `mount` it may be nescessary to specify a CVMFS located configuration_repository.
 #    This is a repository containing extra cvmfs configuration required to be mounted before any other
 #    repositories. There is at most one config_repo client. In addition the config_repo must actually be mounted
 #    explicitly with a `cvmfs::mount{$config_repo:}`, this is **not** automatic.
@@ -118,7 +118,7 @@
 # @param cvmfs_fsck_onreboot Should fsck be run after every reboot
 # @param fuse3
 #   Install or disable fuse3 variant of cvmfs, if left `undef` no change will be made. Note that changing
-#   this value when CvmFS mounts are active may well destroy those mounts.
+#   this value when CVMFS mounts are active may well destroy those mounts.
 #   Not availabe on Ubuntu 18.04.
 # @param cvmfs_cache_symlinks If set to yes, enables symlink caching in the kernel.
 # @param cvmfs_streaming_cache If set to yes, use a download manager to download regular files on read.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,6 +54,11 @@
 #    The `autofs` option will configure cvmfs to be mounted with autofs. The `mount` option will
 #    use puppet's mount type, currently adding a line to /etc/fstab. The *none* option
 #    skips all mounting.  Note that migrating between for instance *autofs* and then *mount* is not supported.
+# @param config_repo
+#    When using the `mount_method` as `mount` it may be nescessary to specify a CvmFS located configuration_repository.
+#    This is a repository containing extra cvmfs configuration required to be mounted before any other
+#    repositories. There is at most one config_repo client. In addition the config_repo must actually be mounted
+#    explicitly with a `cvmfs::mount{$config_repo:}`, this is **not** automatic.
 # @param manage_autofs_service should the autofs service be maintained.
 # @param cvmfs_quota_limit The cvmfs quota size in megabytes.
 # @param cvmfs_quota_ratio
@@ -143,6 +148,7 @@ class cvmfs (
   Variant[Undef,String] $cvmfs_http_proxy,
   Optional[Variant[Enum['absent'], Array[String[1]]]] $repo_includepkgs,
   Enum['autofs','mount','none'] $mount_method                         = 'autofs',
+  Optional[Stdlib::Fqdn] $config_repo                                 = undef,
   Boolean $manage_autofs_service                                      = true,
   Integer $default_cvmfs_partsize                                     = 10000,
   Variant[Enum['auto'],Integer] $cvmfs_quota_limit                    = 1000,

--- a/spec/defines/mount_spec.rb
+++ b/spec/defines/mount_spec.rb
@@ -108,16 +108,6 @@ describe 'cvmfs::mount' do
 
           it { is_expected.to contain_mount('/cvmfs/files.example.org').with_options('one,two,three') }
         end
-
-        context 'with mount_options set to a string' do
-          let(:params) do
-            {
-              mount_options: 'four,five,six',
-            }
-          end
-
-          it { is_expected.to contain_mount('/cvmfs/files.example.org').with_options('four,five,six') }
-        end
       end
 
       context 'with mount_method mount and a config_repo set on main class' do

--- a/spec/defines/mount_spec.rb
+++ b/spec/defines/mount_spec.rb
@@ -3,13 +3,14 @@
 require 'spec_helper'
 
 describe 'cvmfs::mount' do
-  let(:pre_condition) do
-    'class{"cvmfs": cvmfs_http_proxy => undef}'
-  end
   let(:title) { 'files.example.org' }
 
   on_supported_os.each do |os, facts|
     context "on #{os}" do
+      let(:pre_condition) do
+        ['class{"cvmfs": cvmfs_http_proxy => undef}']
+      end
+
       let(:facts) do
         facts
       end
@@ -22,19 +23,25 @@ describe 'cvmfs::mount' do
         it { is_expected.to compile.with_all_deps }
 
         it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local') }
-        it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').with_content("# cvmfs files.example.org.local file installed with puppet.\n# this files overrides and extends the values contained\n# within the files.example.org.conf file.\n\n") }
-        it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').without_content(%r{.*CVMFS_MEMCACHE_SIZE.*$}) }
-        it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').without_content(%r{.*CVMFS_USE_GEOAPI.*$}) }
-        it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').without_content(%r{.*CVMFS_FOLLOW_REDIRECTS.*$}) }
-        it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').without_content(%r{.*CVMFS_CLAIM_OWNERSHIP.*$}) }
-        it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').without_content(%r{.*CVMFS_REPOSITORY_TAG.*$}) }
-        it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').without('content' => %r{^CVMFS_HTTP_PROXY.*$}) }
-        it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').without('content' => %r{^CVMFS_QUOTA_LIMIT.*$}) }
-        it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').without('content' => %r{^CVMFS_EXTERNAL_FALLBACK_PROXY=.*$}) }
-        it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').without('content' => %r{^CVMFS_EXTERNAL_HTTP_PROXY=.*$}) }
-        it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').without('content' => %r{^CVMFS_EXTERNAL_TIMEOUT=.*$}) }
-        it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').without('content' => %r{^CVMFS_EXTERNAL_TIMEOUT_DIRECT=.*$}) }
-        it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').without('content' => %r{^CVMFS_EXTERNAL_URL=.*$}) }
+
+        it {
+          is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').
+            without_content(%r{.*CVMFS_MEMCACHE_SIZE.*$}).
+            without_content(%r{.*CVMFS_USE_GEOAPI.*$}).
+            without_content(%r{.*CVMFS_FOLLOW_REDIRECTS.*$}).
+            without_content(%r{.*CVMFS_CLAIM_OWNERSHIP.*$}).
+            without_content(%r{.*CVMFS_REPOSITORY_TAG.*$}).
+            without_content(%r{^CVMFS_HTTP_PROXY.*$}).
+            without_content(%r{^CVMFS_QUOTA_LIMIT.*$}).
+            without_content(%r{^CVMFS_EXTERNAL_FALLBACK_PROXY=.*$}).
+            without_content(%r{^CVMFS_EXTERNAL_HTTP_PROXY=.*$}).
+            without_content(%r{^CVMFS_EXTERNAL_TIMEOUT=.*$}).
+            without_content(%r{^CVMFS_EXTERNAL_TIMEOUT_DIRECT=.*$}).
+            without_content(%r{^CVMFS_EXTERNAL_URL=.*$}).
+            with_content("# cvmfs files.example.org.local file installed with puppet.\n# this files overrides and extends the values contained\n# within the files.example.org.conf file.\n\n")
+        }
+
+        it { is_expected.not_to contain_mount('/cvmfs/files.example.org') }
 
         context 'with lots of parameters set' do
           let(:params) do
@@ -56,23 +63,86 @@ describe 'cvmfs::mount' do
             }
           end
 
-          it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').with('content' => %r{^CVMFS_MEMCACHE_SIZE=2000$}) }
-          it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').with('content' => %r{^CVMFS_USE_GEOAPI='yes'$}) }
-          it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').with('content' => %r{^CVMFS_FOLLOW_REDIRECTS='yes'$}) }
-          it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').with('content' => %r{^CVMFS_CLAIM_OWNERSHIP='yes'$}) }
-          it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').with('content' => %r{^CVMFS_REPOSITORY_TAG='testing'$}) }
-          it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').with('content' => %r{^CVMFS_UID_MAP='/etc/cvmfs/config.d/files.example.org.uid_map'$}) }
-          it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').with('content' => %r{^CVMFS_GID_MAP='/etc/cvmfs/config.d/files.example.org.gid_map'$}) }
-          it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').with('content' => %r{^CVMFS_QUOTA_LIMIT='54321'$}) }
-          it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').with('content' => %r{^CVMFS_KEYS_DIR='/etc/cvmfs/keys/example.org'$}) }
-          it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').with('content' => %r{^CVMFS_EXTERNAL_FALLBACK_PROXY='http://external-fallback.example.org:3128'$}) }
-          it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').with('content' => %r{^CVMFS_EXTERNAL_HTTP_PROXY='http://http-proxy.example.org:2138'$}) }
-          it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').with('content' => %r{^CVMFS_EXTERNAL_TIMEOUT='100'$}) }
-          it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').with('content' => %r{^CVMFS_EXTERNAL_TIMEOUT_DIRECT='450'$}) }
-          it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').with('content' => %r{^CVMFS_EXTERNAL_URL='http://external-url.example.org:80'$}) }
-          it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.uid_map').with('content' => %r{^123 12$}) }
-          it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.gid_map').with('content' => %r{^137 42$}) }
+          it {
+            is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.local').with_content(%r{^CVMFS_MEMCACHE_SIZE=2000$}).
+              with_content(%r{^CVMFS_USE_GEOAPI='yes'$}).
+              with_content(%r{^CVMFS_FOLLOW_REDIRECTS='yes'$}).
+              with_content(%r{^CVMFS_CLAIM_OWNERSHIP='yes'$}).
+              with_content(%r{^CVMFS_REPOSITORY_TAG='testing'$}).
+              with_content(%r{^CVMFS_UID_MAP='/etc/cvmfs/config.d/files.example.org.uid_map'$}).
+              with_content(%r{^CVMFS_GID_MAP='/etc/cvmfs/config.d/files.example.org.gid_map'$}).
+              with_content(%r{^CVMFS_QUOTA_LIMIT='54321'$}).
+              with_content(%r{^CVMFS_KEYS_DIR='/etc/cvmfs/keys/example.org'$}).
+              with_content(%r{^CVMFS_EXTERNAL_FALLBACK_PROXY='http://external-fallback.example.org:3128'$}).
+              with_content(%r{^CVMFS_EXTERNAL_HTTP_PROXY='http://http-proxy.example.org:2138'$}).
+              with_content(%r{^CVMFS_EXTERNAL_TIMEOUT='100'$}).
+              with_content(%r{^CVMFS_EXTERNAL_TIMEOUT_DIRECT='450'$}).
+              with_content(%r{^CVMFS_EXTERNAL_URL='http://external-url.example.org:80'$})
+          }
+
+          it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.uid_map').with_content(%r{^123 12$}) }
+          it { is_expected.to contain_file('/etc/cvmfs/config.d/files.example.org.gid_map').with_content(%r{^137 42$}) }
         end
+      end
+
+      context 'with mount_method mount set on main class' do
+        let(:pre_condition) do
+          'class{"cvmfs": cvmfs_http_proxy => undef,  mount_method => "mount"}'
+        end
+
+        it { is_expected.to compile.with_all_deps }
+
+        it {
+          is_expected.to contain_mount('/cvmfs/files.example.org').with(
+            options: 'defaults,_netdev,nodev',
+            device: 'files.example.org'
+          )
+        }
+
+        context 'with mount_options set to an array' do
+          let(:params) do
+            {
+              mount_options: %w[one two three],
+            }
+          end
+
+          it { is_expected.to contain_mount('/cvmfs/files.example.org').with_options('one,two,three') }
+        end
+
+        context 'with mount_options set to a string' do
+          let(:params) do
+            {
+              mount_options: 'four,five,six',
+            }
+          end
+
+          it { is_expected.to contain_mount('/cvmfs/files.example.org').with_options('four,five,six') }
+        end
+      end
+
+      context 'with mount_method mount and a config_repo set on main class' do
+        let(:pre_condition) do
+          [
+            'class{"cvmfs": cvmfs_http_proxy => undef,  mount_method => "mount", config_repo => "cvmfs-config.example.org"}',
+            'cvmfs::mount{"cvmfs-config.example.org":}',
+          ]
+        end
+
+        it { is_expected.to compile.with_all_deps }
+
+        it {
+          is_expected.to contain_mount('/cvmfs/files.example.org').with(
+            options: 'defaults,_netdev,nodev,x-systemd.requires-mounts-for=/cvmfs/cvmfs-config.example.org',
+            device: 'files.example.org'
+          )
+        }
+
+        it {
+          is_expected.to contain_mount('/cvmfs/cvmfs-config.example.org').with(
+            options: 'defaults,_netdev,nodev',
+            device: 'cvmfs-config.example.org'
+          )
+        }
       end
     end
   end


### PR DESCRIPTION
#### Pull Request (PR) description

This patch only comes into play when using the `mount_method` of `mount` rather than the default autofs.

It is now possible to specify that one particular repository on a client is the configuration repository and must be mounted first before all other repositories. This should happen during puppets initial configuration of CvmFS and also at reboot.

```puppet
class{'cvmfs':
  mount_method => 'mount',
  config_repo  => 'cvmfs-config.example.org',
}
cmvfs::mount{'myrepo.example.org':}
cmvfs::mount{'cvmfs-config.example.org':}
```

In this example the repository `cvmfs-config.example.org` will be mounted before `myrepo.example.org`.

Note there is all ways at most one configuration repository per client.

#### This Pull Request (PR) fixes the following issues
Fixes: #176

In addition a couple of parameters to `cvmfs::mount` are made bettter:

* `mount_method` to `cvmfs::mount` never made sense and setting it is pointless unless also set in the main class.
   deprecate the parameter. It will still be accepted now but is redundant. It was already documented as 'DO NOT SET'.
* `mount_options` now defaults to an Array of options but a String is still accepted for now.

