### PR TITLE
Add ownership of cachedir to puppet if claiming ownership

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,6 +5,7 @@ class cvmfs::install (
   String[1] $cvmfs_version = $cvmfs::cvmfs_version,
   Stdlib::Absolutepath $cvmfs_cache_base = $cvmfs::cvmfs_cache_base,
   Optional[Boolean] $fuse3 = $cvmfs::fuse3,
+  Optional[Enum['yes','no']] $cvmfs_claim_ownership = $cvmfs::cvmfs_claim_ownership,
 ) inherits cvmfs {
   # Create the cache dir if one is defined, otherwise assume default is in the package.
   # Require the package so we know the user is in place.
@@ -14,7 +15,7 @@ class cvmfs::install (
   # Compare the default value with the one from hiera if declared
   $default_cvmfs_cache_base  = '/var/lib/cvmfs'
 
-  if $cvmfs_cache_base != $default_cvmfs_cache_base {
+  if ($cvmfs_claim_ownership == 'yes') or ($cvmfs_cache_base != $default_cvmfs_cache_base) {
     file { $cvmfs_cache_base:
       ensure  => directory,
       owner   => $cvmfs::cvmfs_cache_owner,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -531,6 +531,7 @@ describe 'cvmfs' do
             it do
               is_expected.to contain_concat__fragment('cvmfs_default_local_header').
                 without_content(%r{^CVMFS_CLAIM_OWNERSHIP})
+              is_expected.not_to contain_file('/var/lib/cvmfs')
             end
           end
 
@@ -543,6 +544,7 @@ describe 'cvmfs' do
             it do
               is_expected.to contain_concat__fragment('cvmfs_default_local_header').
                 with_content(%r{^CVMFS_CLAIM_OWNERSHIP='yes'$})
+              is_expected.to contain_file('/var/lib/cvmfs').with_owner('cvmfs').with_group('cvmfs')
             end
           end
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Add ownership of cvmfs cachedir to puppet when `cvmfs::cvmfs_claim_ownership` - `"yes"`

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
