### PR TITLE
add cvmfs-future repository

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -128,11 +128,13 @@ The following parameters are available in the `cvmfs` class:
 * [`cvmfs_max_ttl`](#-cvmfs--cvmfs_max_ttl)
 * [`cvmfs_version`](#-cvmfs--cvmfs_version)
 * [`repo_base`](#-cvmfs--repo_base)
+* [`repo_base_alt`](#-cvmfs--repo_base_alt)
 * [`repo_includepkgs`](#-cvmfs--repo_includepkgs)
 * [`repo_priority`](#-cvmfs--repo_priority)
 * [`repo_proxy`](#-cvmfs--repo_proxy)
 * [`repo_config_enabled`](#-cvmfs--repo_config_enabled)
 * [`repo_testing_enabled`](#-cvmfs--repo_testing_enabled)
+* [`repo_future_enabled`](#-cvmfs--repo_future_enabled)
 * [`repo_gpgcheck`](#-cvmfs--repo_gpgcheck)
 * [`repo_gpgkey`](#-cvmfs--repo_gpgkey)
 * [`repo_manage`](#-cvmfs--repo_manage)
@@ -394,7 +396,13 @@ Default value: `'present'`
 
 Data type: `Stdlib::Httpurl`
 
-URL containting stable, testing and config apt or yum repositories. Default in hiera data.
+URL containing stable, testing and config apt or yum repositories. Default in hiera data.
+
+##### <a name="-cvmfs--repo_base_alt"></a>`repo_base_alt`
+
+Data type: `Stdlib::Httpurl`
+
+URL containing stable, Same as repo_base, hosted on a different backend. Default in hiera data.
 
 ##### <a name="-cvmfs--repo_includepkgs"></a>`repo_includepkgs`
 
@@ -431,6 +439,14 @@ Default value: `false`
 Data type: `Boolean`
 
 Should the testing repository be enabled.
+
+Default value: `false`
+
+##### <a name="-cvmfs--repo_future_enabled"></a>`repo_future_enabled`
+
+Data type: `Boolean`
+
+Should the future (pre-release) repository be enabled.
 
 Default value: `false`
 

--- a/data/family/Debian.yaml
+++ b/data/family/Debian.yaml
@@ -1,4 +1,5 @@
 ---
 
 cvmfs::repo_base:   https://cvmrepo.s3.cern.ch/cvmrepo/apt
+cvmfs::repo_base_alt:   https://cvmrepo.web.cern.ch/cvmrepo/apt
 cvmfs::repo_gpgkey: https://cvmrepo.s3.cern.ch/cvmrepo/apt/cernvm.gpg

--- a/data/family/RedHat.yaml
+++ b/data/family/RedHat.yaml
@@ -1,6 +1,7 @@
 ---
 
 cvmfs::repo_base: https://cvmrepo.s3.cern.ch/cvmrepo/yum
+cvmfs::repo_base_alt: https://cvmrepo.web.cern.ch/cvmrepo/yum
 cvmfs::repo_gpgkey: https://cvmrepo.s3.cern.ch/cvmrepo/yum/RPM-GPG-KEY-CernVM-2048
 cvmfs::repo_includepkgs:
   - cvmfs-keys

--- a/manifests/apt.pp
+++ b/manifests/apt.pp
@@ -5,6 +5,7 @@ class cvmfs::apt (
   Stdlib::Httpurl $repo_base                                            = $cvmfs::repo_base,
   Stdlib::Httpurl $repo_gpgkey                                          = $cvmfs::repo_gpgkey,
   Boolean $repo_testing_enabled                                         = $cvmfs::repo_testing_enabled,
+  Boolean $repo_future_enabled                                          = $cvmfs::repo_future_enabled,
   Optional[Stdlib::Httpurl] $repo_proxy                                 = $cvmfs::repo_proxy,
   Boolean $repo_gpgcheck                                                = $cvmfs::repo_gpgcheck,
 
@@ -30,5 +31,9 @@ class cvmfs::apt (
   apt::source { 'cvmfs-testing':
     ensure  => bool2str($repo_testing_enabled,'present','absent'),
     release => "${facts['os']['distro']['codename']}-testing",
+  }
+  apt::source { 'cvmfs-future':
+    ensure  => bool2str($repo_future_enabled,'present','absent'),
+    release => "${facts['os']['distro']['codename']}-future",
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -82,12 +82,14 @@
 # @param cvmfs_debuglog Create a debug log file at this location.
 # @param cvmfs_max_ttl Max ttl.
 # @param cvmfs_version Version of cvmfs to install.
-# @param repo_base URL containting stable, testing and config apt or yum repositories. Default in hiera data.
+# @param repo_base URL containing stable, testing and config apt or yum repositories. Default in hiera data.
+# @param repo_base_alt URL containing stable, Same as repo_base, hosted on a different backend. Default in hiera data.
 # @param repo_includepkgs Specify an includepkgs to the yum repos to ignore other packages.
 # @param repo_priority Yum priority of repositories
 # @param repo_proxy http proxy for cvmfs yum package repository
 # @param repo_config_enabled Should the config yum repository be enabled
 # @param repo_testing_enabled Should the testing repository be enabled.
+# @param repo_future_enabled Should the future (pre-release) repository be enabled.
 # @param repo_gpgcheck  set to false to disable GPG checking
 # @param repo_gpgkey Set a custom GPG key for yum repos. Default in hiera data.
 # @param repo_manage Set to false to disable yum or apt repositories management.
@@ -135,6 +137,7 @@
 #
 class cvmfs (
   Stdlib::Httpurl $repo_base,
+  Stdlib::Httpurl $repo_base_alt,
   Stdlib::Httpurl $repo_gpgkey,
   Variant[Undef,String] $cvmfs_http_proxy,
   Optional[Variant[Enum['absent'], Array[String[1]]]] $repo_includepkgs,
@@ -168,6 +171,7 @@ class cvmfs (
   Integer $repo_priority                                              = 80,
   Boolean $repo_config_enabled                                        = false,
   Boolean $repo_testing_enabled                                       = false,
+  Boolean $repo_future_enabled                                        = false,
   Optional[Stdlib::Httpurl] $repo_proxy                               = undef,
   Boolean $repo_gpgcheck                                              = true,
   Optional[Enum['yes','no']] $cvmfs_use_geoapi                        = undef,

--- a/manifests/yum.pp
+++ b/manifests/yum.pp
@@ -3,10 +3,12 @@
 #
 class cvmfs::yum (
   Stdlib::Httpurl $repo_base                                            = $cvmfs::repo_base,
+  Stdlib::Httpurl $repo_base_alt                                        = $cvmfs::repo_base_alt,
   Stdlib::Httpurl $repo_gpgkey                                          = $cvmfs::repo_gpgkey,
   Integer $repo_priority                                                = $cvmfs::repo_priority,
   Boolean $repo_config_enabled                                          = $cvmfs::repo_config_enabled,
   Boolean $repo_testing_enabled                                         = $cvmfs::repo_testing_enabled,
+  Boolean $repo_future_enabled                                          = $cvmfs::repo_future_enabled,
   Optional[Stdlib::Httpurl] $repo_proxy                                 = $cvmfs::repo_proxy,
   Boolean $repo_gpgcheck                                                = $cvmfs::repo_gpgcheck,
   Optional[Variant[Enum['absent'], Array[String[1]]]] $repo_includepkgs = $cvmfs::repo_includepkgs,
@@ -38,9 +40,16 @@ class cvmfs::yum (
   }
 
   yumrepo { 'cvmfs-testing':
-    descr   => "CVMFS yum testing repository for ${_dir}${facts['os']['release']['major']}",
+    descr   => "CVMFS-testing yum repository for ${_dir}${facts['os']['release']['major']}. Same binaries as production repo, released earlier. Very stable.",
     baseurl => "${repo_base}/cvmfs-testing/${_dir}/${facts['os']['release']['major']}/${facts['os']['architecture']}",
     enabled => $repo_testing_enabled,
+  }
+
+  yumrepo { 'cvmfs-future':
+    descr   => "CVMFS-future yum repository for ${_dir}${facts['os']['release']['major']}. Tagged pre-releases. Stable.",
+    # note the use of repo_base_alt - this is in principle a mirror of repo_base, but prereleases are published there first
+    baseurl => "${repo_base_alt}/cvmfs-future/${_dir}/${facts['os']['release']['major']}/${facts['os']['architecture']}",
+    enabled => $repo_future_enabled,
   }
 
   yumrepo { 'cvmfs-config':

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -121,6 +121,13 @@ describe 'cvmfs' do
             end
 
             it do
+              is_expected.to contain_yumrepo('cvmfs-future').with(
+                'enabled' => false,
+                'gpgcheck' => true
+              )
+            end
+
+            it do
               is_expected.to contain_yumrepo('cvmfs-config').with(
                 'enabled' => false,
                 'gpgcheck' => true,
@@ -159,6 +166,31 @@ describe 'cvmfs' do
                     'location' => 'https://cvmrepo.s3.cern.ch/cvmrepo/apt',
                     'release' => 'bookworm-testing',
                     'allow_unsigned' => false,
+                  }
+                )
+              }
+            end
+          end
+
+          context 'with repo_future_enabled true' do
+            let(:params) do
+              { repo_future_enabled: true,
+                cvmfs_http_proxy: :undef }
+            end
+
+            case facts[:os]['family']
+            when 'RedHat'
+              it do
+                is_expected.to contain_yumrepo('cvmfs-future').with(
+                  'enabled' => true,
+                  'gpgcheck' => true
+                )
+              end
+            else
+              it {
+                is_expected.to contain_apt__source('cvmfs-future').with(
+                  {
+                    'ensure' => 'present',
                   }
                 )
               }


### PR DESCRIPTION
#### Pull Request (PR) description

Add the new cvmfs-future repository for anyone who wishes to enable it. This serves tagged prerelease versions, but is expected to be stable.

Currently only populated with cvmfs-2.13.2~pre2-1.el{8,9}, but other platforms will follow.