### PR TITLE
Drop puppet and openvox 7 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -82,11 +82,11 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 7.0.0 < 9.0.0"
+      "version_requirement": ">= 8.0.0 < 9.0.0"
     },
     {
       "name": "openvox",
-      "version_requirement": ">= 7.0.0 < 9.0.0"
+      "version_requirement": ">= 8.0.0 < 9.0.0"
     }
   ]
 }


### PR DESCRIPTION
#### Pull Request (PR) description

Recent versions of puppetlabs-apt have dropped ruby 2.7 support with:

https://github.com/puppetlabs/puppetlabs-apt/commit/3f9afe6a4840a5804a740d924f6fde0b277db8e0

More over support for 7 is going to be dropped globally anyway:

https://github.com/voxpupuli/modulesync_config/pull/978