### PR TITLE
apt: ensure RSA signing key is refreshed instead of old DSA key

### DIFF
--- a/manifests/apt.pp
+++ b/manifests/apt.pp
@@ -16,7 +16,7 @@ class cvmfs::apt (
     location       => $repo_base,
     key            => {
       ensure  => refreshed,
-      id      => '70B9890488208E315ED45208230D389D8AE45CE7',
+      id      => 'FD80468D49B3B24C341741FC8CE0A76C497EA957',
       source  => $repo_gpgkey,
     },
     repos          => 'main',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -307,7 +307,7 @@ describe 'cvmfs' do
             else
               it {
                 is_expected.to contain_apt__source('cvmfs').with_key(
-                  { 'ensure' => 'refreshed', 'id' => '70B9890488208E315ED45208230D389D8AE45CE7', 'source' => 'http://example.org/key.gpg' }
+                  { 'ensure' => 'refreshed', 'id' => 'FD80468D49B3B24C341741FC8CE0A76C497EA957', 'source' => 'http://example.org/key.gpg' }
                 )
               }
             end


### PR DESCRIPTION
#### Pull Request (PR) description
Upstream has an older dsa1024 signing key and a more recent rsa4096 signing key in place which is used for new releases.
While both keys are provided via the same source URL, existing systems installed before the RSA key was added would never fetch that key, as the DSA key never expires and only that is refreshed via Puppet.

Ensuring the RSA key is refreshed instead of the DSA key ensures that both keys are present and that the RSA key is added also for existing systems.

For completeness:
```
$ wget https://cvmrepo.web.cern.ch/cvmrepo/apt/cernvm.gpg
$ gpg --no-default-keyring --keyring $(pwd)/cernvm.gpg --list-keys
/var/tmp/olifre/cvm/cernvm.gpg
------------------------------
pub   dsa1024 2010-02-25 [SC]
      70B9890488208E315ED45208230D389D8AE45CE7
uid           [ unknown] CernVM Administrator (cvmadmin) <cernvm.administrator@cern.ch>
sub   elg2048 2010-02-25 [E]

pub   rsa4096 2024-11-27 [SC]
      FD80468D49B3B24C341741FC8CE0A76C497EA957
uid           [ unknown] cvmadmin <cernvm.administrator@cern.ch>
sub   rsa4096 2024-11-27 [E]
```
