### PR TITLE
Switch to vagrant hypervisor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,5 @@ jobs:
   puppet:
     name: Puppet
     uses: voxpupuli/gha-puppet/.github/workflows/beaker.yml@v3
+    with:
+      beaker_hypervisor:  'vagrant_libvirt'

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,3 +1,6 @@
 ---
 spec/spec_helper_acceptance.rb:
   unmanaged: false
+
+.github/workflows/ci.yml:
+  beaker_hypervisor: vagrant_libvirt

--- a/spec/acceptance/cvmfs_mount_atlas_repo_spec.rb
+++ b/spec/acceptance/cvmfs_mount_atlas_repo_spec.rb
@@ -4,6 +4,9 @@ require 'spec_helper_acceptance'
 
 describe 'cvmfs::mount atlas.cern.ch' do
   it 'configures and work with no errors' do
+    pending('vargrant image being available') if ((fact('os.name') == 'Rocky') && (fact('os.release.major') == '9')) ||
+                                                 ((fact('os.name') == 'Ubuntu') && (fact('os.release.major') == '24.04'))
+
     shell('cvmfs_config killall', acceptable_exit_codes: [0, 127])
     pp = <<-EOS
          class{"cvmfs":

--- a/spec/acceptance/cvmfs_mount_cern_domain_spec.rb
+++ b/spec/acceptance/cvmfs_mount_cern_domain_spec.rb
@@ -4,6 +4,9 @@ require 'spec_helper_acceptance'
 
 describe 'cvmfs::domain cern.ch' do
   it 'configures and work with no errors' do
+    pending('vargrant image being available') if ((fact('os.name') == 'Rocky') && (fact('os.release.major') == '9')) ||
+                                                 ((fact('os.name') == 'Ubuntu') && (fact('os.release.major') == '24.04'))
+
     # Clean up all existing mounts
     shell('cvmfs_config killall', acceptable_exit_codes: [0, 127])
     pp = <<-EOS

--- a/spec/acceptance/cvmfs_prom_enable_spec.rb
+++ b/spec/acceptance/cvmfs_prom_enable_spec.rb
@@ -4,6 +4,9 @@ require 'spec_helper_acceptance'
 
 describe 'cvmfs enable_prometheus_exporter' do
   it 'configures and work with no errors' do
+    pending('vargrant image being available') if ((fact('os.name') == 'Rocky') && (fact('os.release.major') == '9')) ||
+                                                 ((fact('os.name') == 'Ubuntu') && (fact('os.release.major') == '24.04'))
+
     # Clean up all existing mounts
     shell('cvmfs_config killall', acceptable_exit_codes: [0, 127])
     pp = <<-PUPPET


### PR DESCRIPTION
#### Pull Request (PR) description

Working with kernel modules (autofs) and rootless podman is just to hard for acceptance tests.

Test failure for Rocky 10 and Ubuntu 24.04 since no vagrant definition. I presume.
