### PR TITLE
Support CVMFS_PREFETCH_FILEBUNDLES=yes||no

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -156,6 +156,7 @@ The following parameters are available in the `cvmfs` class:
 * [`default_cvmfs_partsize`](#-cvmfs--default_cvmfs_partsize)
 * [`cvmfs_domain_hash`](#-cvmfs--cvmfs_domain_hash)
 * [`cvmfs_send_info_header`](#-cvmfs--cvmfs_send_info_header)
+* [`cvmfs_prefetch_filebundles`](#-cvmfs--cvmfs_prefetch_filebundles)
 * [`cvmfs_instrument_fuse`](#-cvmfs--cvmfs_instrument_fuse)
 * [`cvmfs_repo_list`](#-cvmfs--cvmfs_repo_list)
 * [`cvmfs_alien_cache`](#-cvmfs--cvmfs_alien_cache)
@@ -544,6 +545,14 @@ Default value: `{}`
 Data type: `Optional[Enum['yes','no']]`
 
 Include the cvmfs path of downloaded data in HTTP headers.
+
+Default value: `undef`
+
+##### <a name="-cvmfs--cvmfs_prefetch_filebundles"></a>`cvmfs_prefetch_filebundles`
+
+Data type: `Optional[Enum['yes','no']]`
+
+Enable prefetching of published filebundles.
 
 Default value: `undef`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -41,6 +41,7 @@ class cvmfs::config (
   Optional[Array[String[1],1]] $cvmfs_xattr_protected_xattrs          = $cvmfs::cvmfs_xattr_protected_xattrs,
   Optional[String[1]] $cvmfs_repositories                             = $cvmfs::cvmfs_repositories,
   Optional[Enum['yes','no']] $cvmfs_send_info_header                  = $cvmfs::cvmfs_send_info_header,
+  Optional[Enum['yes','no']] $cvmfs_prefetch_filebundles               = $cvmfs::cvmfs_prefetch_filebundles,
 ) inherits cvmfs {
   # If cvmfspartsize fact exists use it, otherwise use a sensible default.
   if $facts['cvmfspartsize'] {
@@ -147,6 +148,7 @@ class cvmfs::config (
         'cvmfs_xattr_privileged_gids'  => $cvmfs_xattr_privileged_gids,
         'cvmfs_xattr_protected_xattrs' => $cvmfs_xattr_protected_xattrs,
         'cvmfs_send_info_header'       => $cvmfs_send_info_header,
+        'cvmfs_prefetch_filebundles'   => $cvmfs_prefetch_filebundles,
       }
     ),
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -116,6 +116,7 @@
 # @param default_cvmfs_partsize
 # @param cvmfs_domain_hash Specify of a hash `cvmfs::domain` types.
 # @param cvmfs_send_info_header Include the cvmfs path of downloaded data in HTTP headers.
+# @param cvmfs_prefetch_filebundles Enable prefetching of published filebundles.
 # @param cvmfs_instrument_fuse  Instrument Fuse
 # @param cvmfs_repo_list Specify exactly the REPO_LIST in `defaults.local` overriding auto population.
 # @param cvmfs_alien_cache Use an alien cache
@@ -220,6 +221,7 @@ class cvmfs (
   Optional[Variant[Stdlib::Filesource,Stdlib::Httpurl]] $cvmfs_yum_gpgkey = undef,
   Optional[Variant[Enum['absent'], Array[String]]] $cvmfs_yum_includepkgs = undef,
   Optional[Enum['yes','no']] $cvmfs_send_info_header                      = undef,
+  Optional[Enum['yes','no']] $cvmfs_prefetch_filebundles                 = undef,
 
 ) {
   # Deprecations

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -590,6 +590,7 @@ describe 'cvmfs' do
                 .without_content(%r{CVMFS_XATTR_PRIVILEGED_GIDS})
                 .without_content(%r{CVMFS_XATTR_PRIVILEGED_XATTRS})
                 .without_content(%r{CVMFS_SEND_INFO_HEADER})
+                .without_content(%r{CVMFS_PREFETCH_FILEBUNDLES})
                 .without_content(%r{CVMFS_CACHE_REFCOUNT})
             end
           end
@@ -607,6 +608,7 @@ describe 'cvmfs' do
                 cvmfs_xattr_protected_xattrs: ['user.foo', 'user.bar'],
                 cvmfs_cache_refcount: 'no',
                 cvmfs_send_info_header: 'yes',
+                cvmfs_prefetch_filebundles: 'yes',
               }
             end
 
@@ -620,6 +622,7 @@ describe 'cvmfs' do
                 .with_content(%r{^CVMFS_CPU_AFFINITY='0,1,2'$})
                 .with_content(%r{^CVMFS_XATTR_PRIVILEGED_GIDS='100,101,102'$})
                 .with_content(%r{^CVMFS_SEND_INFO_HEADER=yes$})
+                .with_content(%r{^CVMFS_PREFETCH_FILEBUNDLES=yes$})
                 .with_content(%r{^CVMFS_XATTR_PROTECTED_XATTRS='user.foo,user.bar'$})
             end
           end

--- a/templates/repo.local.epp
+++ b/templates/repo.local.epp
@@ -43,6 +43,7 @@
   Optional[Array[Integer[1],1]]                $cvmfs_xattr_privileged_gids = undef,
   Optional[Array[String[1],1]]                 $cvmfs_xattr_protected_xattrs = undef,
   Optional[Enum['yes','no']]                   $cvmfs_send_info_header = undef,
+  Optional[Enum['yes','no']]                   $cvmfs_prefetch_filebundles = undef,
 
 | -%>
 <% if $repo { -%>
@@ -158,6 +159,9 @@ CVMFS_INSTRUMENT_FUSE=<%= $cvmfs_instrument_fuse %>
 <% } -%>
 <% if $cvmfs_send_info_header { -%>
 CVMFS_SEND_INFO_HEADER=<%= $cvmfs_send_info_header %>
+<% } -%>
+<% if $cvmfs_prefetch_filebundles { -%>
+CVMFS_PREFETCH_FILEBUNDLES=<%= $cvmfs_prefetch_filebundles %>
 <% } -%>
 <%-
   [


### PR DESCRIPTION
CVMFS 2.14.1. includes an option to do filebundle prefetching, which should speed up cvmfs in interactive workflows if the cvmfs repository has published filebundles and is intended for interactive clusters like lxplus (see CHEP presentation for more details: https://indico.cern.ch/event/1471803/contributions/6967096/ )