### PR TITLE
Drop EOL Fedora 42

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -74,7 +74,6 @@
     {
       "operatingsystem": "Fedora",
       "operatingsystemrelease": [
-        "42",
         "43"
       ]
     }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -150,26 +150,14 @@ describe 'cvmfs' do
               )
             end
           when 'Fedora'
-            case facts[:os]['release']['major']
-            when '42'
-              it {
-                is_expected.to contain_yumrepo('cvmfs')
-                  .with_baseurl('https://cvmrepo.s3.cern.ch/cvmrepo/yum/cvmfs/fedora/42/x86_64 https://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs/fedora/42/x86_64')
-                is_expected.to contain_yumrepo('cvmfs-testing')
-                  .with_baseurl('https://cvmrepo.s3.cern.ch/cvmrepo/yum/cvmfs-testing/fedora/42/x86_64 https://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs-testing/fedora/42/x86_64')
-                is_expected.to contain_yumrepo('cvmfs-config')
-                  .with_baseurl('https://cvmrepo.s3.cern.ch/cvmrepo/yum/cvmfs-config/fedora/42/x86_64 https://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs-config/fedora/42/x86_64')
-              }
-            else
-              it {
-                is_expected.to contain_yumrepo('cvmfs')
-                  .with_baseurl('https://cvmrepo.s3.cern.ch/cvmrepo/yum/cvmfs/fedora/43/x86_64 https://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs/fedora/43/x86_64')
-                is_expected.to contain_yumrepo('cvmfs-testing')
-                  .with_baseurl('https://cvmrepo.s3.cern.ch/cvmrepo/yum/cvmfs-testing/fedora/43/x86_64 https://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs-testing/fedora/43/x86_64')
-                is_expected.to contain_yumrepo('cvmfs-config')
-                  .with_baseurl('https://cvmrepo.s3.cern.ch/cvmrepo/yum/cvmfs-config/fedora/43/x86_64 https://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs-config/fedora/43/x86_64')
-              }
-            end
+            it {
+              is_expected.to contain_yumrepo('cvmfs')
+                .with_baseurl('https://cvmrepo.s3.cern.ch/cvmrepo/yum/cvmfs/fedora/43/x86_64 https://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs/fedora/43/x86_64')
+              is_expected.to contain_yumrepo('cvmfs-testing')
+                .with_baseurl('https://cvmrepo.s3.cern.ch/cvmrepo/yum/cvmfs-testing/fedora/43/x86_64 https://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs-testing/fedora/43/x86_64')
+              is_expected.to contain_yumrepo('cvmfs-config')
+                .with_baseurl('https://cvmrepo.s3.cern.ch/cvmrepo/yum/cvmfs-config/fedora/43/x86_64 https://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs-config/fedora/43/x86_64')
+            }
           else
             it {
               is_expected.to contain_apt__source('cvmfs').with(


### PR DESCRIPTION
#### Pull Request (PR) description

Fedora 42 is EOL since - 2026-05-27

