### PR TITLE
 Rely on central install in beaker of iproute

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ end
 
 group :system_tests do
   gem 'voxpupuli-acceptance', '~> 4.4',  :require => false
+  gem 'beaker', :git => 'https://github.com/traylenator/beaker.git', :branch => 'ss'
 end
 
 group :release do

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -476,9 +476,9 @@ Default value: `true`
 
 ##### <a name="-cvmfs--repo_gpgkey"></a>`repo_gpgkey`
 
-Data type: `Stdlib::Httpurl`
+Data type: `Variant[Stdlib::Httpurl,Array[Stdlib::Httpurl,1]]`
 
-Set a custom GPG key for yum repos. Default in hiera data.
+Set a custom GPG key(s) for yum, apt repos. Only RedHat family supports more than one gpg key. Default in hiera data.
 
 ##### <a name="-cvmfs--repo_manage"></a>`repo_manage`
 

--- a/data/name/Fedora/43.yaml
+++ b/data/name/Fedora/43.yaml
@@ -1,0 +1,4 @@
+---
+cvmfs::repo_gpgkey:
+  - https://cvmrepo.s3.cern.ch/cvmrepo/yum/RPM-GPG-KEY-CernVM
+  - https://cvmrepo.s3.cern.ch/cvmrepo/yum/RPM-GPG-KEY-CernVM-2048

--- a/manifests/apt.pp
+++ b/manifests/apt.pp
@@ -3,19 +3,23 @@
 #
 class cvmfs::apt (
   Variant[Stdlib::Httpurl,Array[Stdlib::Httpurl,1]] $repo_base          = $cvmfs::repo_base,
-  Stdlib::Httpurl $repo_gpgkey                                          = $cvmfs::repo_gpgkey,
+  Variant[Stdlib::Httpurl,Array[Stdlib::Httpurl,1]] $repo_gpgkey        = $cvmfs::repo_gpgkey,
   Boolean $repo_testing_enabled                                         = $cvmfs::repo_testing_enabled,
   Boolean $repo_future_enabled                                          = $cvmfs::repo_future_enabled,
   Optional[Stdlib::Httpurl] $repo_proxy                                 = $cvmfs::repo_proxy,
   Boolean $repo_gpgcheck                                                = $cvmfs::repo_gpgcheck,
 ) {
+  if $repo_gpgkey =~ Array[Stdlib::Httpurl,2] {
+    fail('On Debian or Ubuntu only one repo_gpgkey URL is supported')
+  }
+
   if ($facts['os']['name'] == 'Debian' and versioncmp($facts['os']['release']['major'],'12') <= 0 ) or
   ($facts['os']['name'] == 'Ubuntu' and versioncmp($facts['os']['release']['major'],'24.04') <= 0 ) {
     $_source_format = 'list'
     $_key           = {
       ensure  => refreshed,
       id      => 'FD80468D49B3B24C341741FC8CE0A76C497EA957',
-      source  => $repo_gpgkey,
+      source  => Array($repo_gpgkey,true).join(''),  # array length one at most
     }
     $_keyring = undef
     # We already reject arrays of more than one element in init.pp
@@ -53,7 +57,7 @@ class cvmfs::apt (
     $_repo_future_enabled = $repo_future_enabled
 
     apt::keyring { 'cernvm.gpg':
-      source => $repo_gpgkey,
+      source => Array($repo_gpgkey,true).join(''), # Array length one at most
       before => [Apt::Source['cvmfs'],Apt::Source['cvmfs-testing'],Apt::Source['cvmfs-future']],
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -100,7 +100,7 @@
 # @param repo_testing_enabled Should the testing repository be enabled.
 # @param repo_future_enabled Should the future (pre-release) repository be enabled.
 # @param repo_gpgcheck  set to false to disable GPG checking
-# @param repo_gpgkey Set a custom GPG key for yum repos. Default in hiera data.
+# @param repo_gpgkey Set a custom GPG key(s) for yum, apt repos. Only RedHat family supports more than one gpg key. Default in hiera data.
 # @param repo_manage Set to false to disable yum or apt repositories management.
 # @param cvmfs_use_geoapi Enable geoapi to find suitable proxies.
 # @param cvmfs_repositories
@@ -150,7 +150,7 @@
 class cvmfs (
   Variant[Stdlib::Httpurl,Array[Stdlib::Httpurl,1]] $repo_base,
   Stdlib::Httpurl $repo_base_alt,
-  Stdlib::Httpurl $repo_gpgkey,
+  Variant[Stdlib::Httpurl,Array[Stdlib::Httpurl,1]] $repo_gpgkey,
   Variant[Undef,String] $cvmfs_http_proxy,
   Optional[Variant[Enum['absent'], Array[String[1]]]] $repo_includepkgs = undef,
   Enum['autofs','mount','none'] $mount_method                         = 'autofs',

--- a/manifests/yum.pp
+++ b/manifests/yum.pp
@@ -4,7 +4,7 @@
 class cvmfs::yum (
   Variant[Stdlib::Httpurl,Array[Stdlib::Httpurl,1]] $repo_base          = $cvmfs::repo_base,
   Stdlib::Httpurl $repo_base_alt                                        = $cvmfs::repo_base_alt,
-  Stdlib::Httpurl $repo_gpgkey                                          = $cvmfs::repo_gpgkey,
+  Variant[Stdlib::Httpurl,Array[Stdlib::Httpurl]] $repo_gpgkey          = $cvmfs::repo_gpgkey,
   Integer $repo_priority                                                = $cvmfs::repo_priority,
   Boolean $repo_config_enabled                                          = $cvmfs::repo_config_enabled,
   Boolean $repo_testing_enabled                                         = $cvmfs::repo_testing_enabled,
@@ -22,7 +22,7 @@ class cvmfs::yum (
 
   Yumrepo {
     gpgcheck    => $repo_gpgcheck,
-    gpgkey      => $repo_gpgkey,
+    gpgkey      => Array($repo_gpgkey,true).join(' '),
     includepkgs => $_yum_includepkgs,
     priority    => $repo_priority,
     proxy       => $repo_proxy,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -496,6 +496,51 @@ describe 'cvmfs' do
             end
           end
 
+          context 'with repo_gpgkey set to array of one url http://example.org/key.gpg' do
+            let(:params) do
+              { repo_gpgkey: ['http://example.org/key.gpg'],
+                cvmfs_http_proxy: :undef, }
+            end
+
+            case facts[:os]['family']
+            when 'RedHat'
+              it { is_expected.to contain_yumrepo('cvmfs').with_gpgkey('http://example.org/key.gpg') }
+              it { is_expected.to contain_yumrepo('cvmfs-testing').with_gpgkey('http://example.org/key.gpg') }
+              it { is_expected.to contain_yumrepo('cvmfs-config').with_gpgkey('http://example.org/key.gpg') }
+            else
+              case [facts[:os]['name'], facts[:os]['release']['major']]
+              when %w[Debian 11], %w[Debian 12], ['Ubuntu', '22.04'], ['Ubuntu', '24.04']
+                it {
+                  is_expected.to contain_apt__source('cvmfs').with_key(
+                    { 'ensure' => 'refreshed', 'id' => 'FD80468D49B3B24C341741FC8CE0A76C497EA957', 'source' => 'http://example.org/key.gpg' },
+                  )
+                  is_expected.to contain_apt__source('cvmfs').without_keyring
+                }
+              else
+                it {
+                  is_expected.to contain_apt__source('cvmfs').with_keyring('/etc/apt/keyrings/cernvm.gpg')
+                  is_expected.to contain_apt__source('cvmfs').without_key
+                }
+              end
+            end
+          end
+
+          context 'with repo_gpgkey set as array multiple URLs' do
+            let(:params) do
+              { repo_gpgkey: ['http://example.org/key.gpg', 'http://example.com/other.gpg'],
+                cvmfs_http_proxy: :undef, }
+            end
+
+            case facts[:os]['family']
+            when 'RedHat'
+              it { is_expected.to contain_yumrepo('cvmfs').with_gpgkey('http://example.org/key.gpg http://example.com/other.gpg') }
+              it { is_expected.to contain_yumrepo('cvmfs-testing').with_gpgkey('http://example.org/key.gpg http://example.com/other.gpg') }
+              it { is_expected.to contain_yumrepo('cvmfs-config').with_gpgkey('http://example.org/key.gpg http://example.com/other.gpg') }
+            else
+              it { is_expected.to compile.and_raise_error(%r{only one repo_gpgkey URL is supported}) }
+            end
+          end
+
           context 'with repo_manage set to true' do
             let(:params) do
               { repo_manage: true,

--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -4,10 +4,3 @@ if $facts['os']['name'] == 'Ubuntu' and $facts['os']['release']['full'] == '18.0
     ensure => present,
   }
 }
-# ss command needed for serverspec port is listening?
-if $facts['os']['name'] == 'Fedora' {
-  package{ 'iproute':
-    ensure => present,
-  }
-}
-

--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -4,4 +4,10 @@ if $facts['os']['name'] == 'Ubuntu' and $facts['os']['release']['full'] == '18.0
     ensure => present,
   }
 }
+# ss command needed for serverspec port is listening?
+if $facts['os']['name'] == 'Fedora' {
+  package{ 'iproute':
+    ensure => present,
+  }
+}
 


### PR DESCRIPTION
#### Pull Request (PR) description

Rely on central install of iproute

This module was installing `iproute` to make `ss` be installed
as required for serverspec's  `port.listening?` function.

Now iproute is installed by beaker itself we can remove the install of
iproute from this module.
