### PR TITLE
Drop dead Ubuntu 18.04 test setup

### DIFF
--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -1,7 +1,0 @@
-# Needed for os.distro.codebase fact
-if $facts['os']['name'] == 'Ubuntu' and $facts['os']['release']['full'] == '18.04' and versioncmp($facts['puppetversion'], '7') <= 0 {
-  package{'lsb-release':
-    ensure => present,
-  }
-}
-


### PR DESCRIPTION
#### Pull Request (PR) description

Some extra test set up for Ubuntu 18.04 and Puppet 7 is long dead - drop.


