### PR TITLE
Use `systemctl start cvmfs-reload.service`

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -136,6 +136,7 @@ The following parameters are available in the `cvmfs` class:
 * [`cvmfs_syslog_level`](#-cvmfs--cvmfs_syslog_level)
 * [`cvmfs_tracefile`](#-cvmfs--cvmfs_tracefile)
 * [`cvmfs_debuglog`](#-cvmfs--cvmfs_debuglog)
+* [`use_config_reload`](#-cvmfs--use_config_reload)
 * [`cvmfs_max_ttl`](#-cvmfs--cvmfs_max_ttl)
 * [`cvmfs_version`](#-cvmfs--cvmfs_version)
 * [`repo_base`](#-cvmfs--repo_base)
@@ -389,6 +390,14 @@ Data type: `Optional[Stdlib::Absolutepath]`
 Create a debug log file at this location.
 
 Default value: `undef`
+
+##### <a name="-cvmfs--use_config_reload"></a>`use_config_reload`
+
+Data type: `Boolean`
+
+If true use `cvmfs_config reload` rather than `cvmfs-reload.service`
+
+Default value: `false`
 
 ##### <a name="-cvmfs--cvmfs_max_ttl"></a>`cvmfs_max_ttl`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -88,6 +88,7 @@
 # @param cvmfs_syslog_level Level to syslog at.
 # @param cvmfs_tracefile Create a tracefile at this location.
 # @param cvmfs_debuglog Create a debug log file at this location.
+# @param use_config_reload If true use `cvmfs_config reload` rather than `cvmfs-reload.service`
 # @param cvmfs_max_ttl Max ttl.
 # @param cvmfs_version Version of cvmfs to install.
 # @param repo_base
@@ -156,6 +157,7 @@ class cvmfs (
   Enum['autofs','mount','none'] $mount_method                         = 'autofs',
   Optional[Stdlib::Fqdn] $config_repo                                 = undef,
   Boolean $manage_autofs_service                                      = true,
+  Boolean $use_config_reload                                          = false,
   Integer $default_cvmfs_partsize                                     = 10000,
   Variant[Enum['auto'],Integer] $cvmfs_quota_limit                    = 1000,
   Float   $cvmfs_quota_ratio                                          = 0.85,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -5,11 +5,15 @@ class cvmfs::service (
   Enum['autofs','mount','none'] $mount_method = $cvmfs::mount_method,
   Boolean $manage_autofs_service = $cvmfs::manage_autofs_service,
   Boolean $enable_prometheus_exporter = $cvmfs::enable_prometheus_exporter,
+  Boolean $use_config_reload = $cvmfs::use_config_reload,
 ) inherits cvmfs {
-  # CVMFS 2.1 at least uses cvmfs_config.
+  $_reload_command = $use_config_reload ? {
+    true    => '/usr/bin/cvmfs_config reload',
+    default => '/usr/bin/systemctl start cvmfs-reload.service',
+  }
 
   exec { 'Reloading cvmfs':
-    command     => '/usr/bin/cvmfs_config reload',
+    command     => $_reload_command,
     refreshonly => true,
   }
   if $manage_autofs_service and $mount_method == 'autofs' {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -35,6 +35,24 @@ describe 'cvmfs' do
           is_expected.to contain_service('cvmfs-client-prometheus.socket').with_ensure(false).with_enable(false)
         }
 
+        it { is_expected.to contain_exec('Reloading cvmfs').with_command('/usr/bin/systemctl start cvmfs-reload.service') }
+
+        context 'with use_config_reload false' do
+          let(:params) do
+            super().merge(use_config_reload: false)
+          end
+
+          it { is_expected.to contain_exec('Reloading cvmfs').with_command('/usr/bin/systemctl start cvmfs-reload.service') }
+        end
+
+        context 'with use_config_reload true' do
+          let(:params) do
+            super().merge(use_config_reload: true)
+          end
+
+          it { is_expected.to contain_exec('Reloading cvmfs').with_command('/usr/bin/cvmfs_config reload') }
+        end
+
         case facts[:os]['family']
         when 'Debian'
           it { is_expected.to contain_class('cvmfs::apt') }


### PR DESCRIPTION
#### Pull Request (PR) description

Previously `/usr/bin/cvmfs_config reload` was always used to reload CvmFS.

The module will now use the `cvmfs-reload.service` static unit.

This was introduced in the now quite old  CvmFS version v2.12.0

The previous behaviour can be restored by setting paramter `use_config_reload` to `true`.

#### This Pull Request (PR) fixes the following issues

* Fixes #242